### PR TITLE
fix: release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Release Please
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
         with:
           release-type: node
           package-name: ydb-qdrant


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR corrects the GitHub Action reference in the Release Please workflow from `google-github-actions/release-please-action` to `googleapis/release-please-action`. The official and maintained Release Please action is under the `googleapis` organization on GitHub, not `google-github-actions`. This is a necessary fix to ensure the workflow uses the correct, officially supported action.

- Updated action reference to use the official `googleapis` organization
- No functional changes to workflow configuration
- Ensures compatibility with the maintained Release Please action

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk - it's a simple correction to use the official Release Please action
- This is a straightforward fix that corrects the GitHub Action organization name from an incorrect reference to the official one. The change is minimal (single line), well-understood, and fixes a potential issue with using an unofficial or deprecated action path. All workflow parameters remain identical, so functionality is preserved while ensuring use of the officially maintained action.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/release-please.yml | 5/5 | Corrected GitHub Action repository from `google-github-actions` to the official `googleapis` organization - proper fix for using the correct Release Please action |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub
    participant RP as Release Please Action<br/>(googleapis)
    participant Repo as Repository

    Dev->>GH: Push to main branch
    GH->>RP: Trigger workflow
    RP->>Repo: Check commit messages<br/>(conventional commits)
    RP->>Repo: Create/Update release PR<br/>with changelog
    Note over RP,Repo: Workflow uses correct<br/>googleapis/release-please-action
    RP->>GH: Create PR or update version
    GH-->>Dev: Release PR ready for merge
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->