### PR TITLE
chore: append readme with example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ pnpm-debug.log*
 
 # Misc caches
 .cache/
-
+ydb-sa.json


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR enhances the README with a practical example showing how to implement a shared client pattern for `ydb-qdrant` in server applications. The example demonstrates lazy initialization with a singleton pattern, which is a common and useful pattern for production use. The PR also adds `ydb-sa.json` to `.gitignore` to prevent accidental exposure of YDB service account credentials.

**Changes:**
- Added complete code example showing singleton client pattern with lazy initialization
- Demonstrates proper async handling with `ReturnType<typeof createYdbQdrantClient>`
- Shows typical usage with `searchPoints` API
- Added `ydb-sa.json` to `.gitignore` for credential security (minor: removed trailing newline)

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no issues - it only adds documentation and security improvements
- The changes are purely additive (documentation example) and improve security (gitignore). The code example follows correct TypeScript patterns and matches the existing API. No logic changes to the codebase.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .gitignore | 5/5 | Added `ydb-sa.json` to gitignore to prevent accidentally committing service account credentials. Also removed trailing newline. |
| README.md | 5/5 | Added comprehensive example demonstrating singleton pattern for shared YDB Qdrant client in server applications with proper async initialization. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application Code
    participant GetClient as getClient()
    participant Client as YdbQdrantClient
    participant YDB as YDB Database
    
    App->>GetClient: Call searchDocuments(collection, queryEmbedding, top)
    GetClient->>GetClient: Check if clientPromise exists
    
    alt First call (clientPromise is null)
        GetClient->>Client: createYdbQdrantClient({defaultTenant: 'myapp'})
        Client->>YDB: Connect and initialize
        YDB-->>Client: Connection established
        Client-->>GetClient: Return client instance
        GetClient->>GetClient: Store promise in clientPromise
    else Subsequent calls (clientPromise exists)
        GetClient->>GetClient: Reuse existing clientPromise
    end
    
    GetClient-->>App: Return client
    App->>Client: searchPoints(collection, {vector, top, with_payload})
    Client->>YDB: Execute vector search query
    YDB-->>Client: Return search results
    Client-->>App: Return result.points ?? []
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->