### PR TITLE
chore: append repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,11 @@ The package entrypoint exports a programmatic API that mirrors the Qdrant HTTP s
 
   async function main() {
     // defaultTenant is optional; defaults to "default"
-    const client = await createYdbQdrantClient({ defaultTenant: "myapp" });
+    const client = await createYdbQdrantClient({
+      defaultTenant: "myapp",
+      endpoint: "grpcs://lb.etn01g9tcilcon2mrt3h.ydb.mdb.yandexcloud.net:2135",
+      database: "/ru-central1/b1ge4v9r1l3h1q4njclp/etn01g9tcilcon2mrt3h",
+    });
 
     await client.createCollection("documents", {
       vectors: {
@@ -111,7 +115,10 @@ The package entrypoint exports a programmatic API that mirrors the Qdrant HTTP s
 
 - Multi-tenant usage with `forTenant`:
   ```ts
-  const client = await createYdbQdrantClient();
+  const client = await createYdbQdrantClient({
+    endpoint: "grpcs://lb.etn01g9tcilcon2mrt3h.ydb.mdb.yandexcloud.net:2135",
+    database: "/ru-central1/b1ge4v9r1l3h1q4njclp/etn01g9tcilcon2mrt3h",
+  });
   const tenantClient = client.forTenant("tenant-a");
 
   await tenantClient.upsertPoints("sessions", {
@@ -132,7 +139,11 @@ let clientPromise: ReturnType<typeof createYdbQdrantClient> | null = null;
 
 async function getClient() {
   if (!clientPromise) {
-    clientPromise = createYdbQdrantClient({defaultTenant: 'myapp'});
+    clientPromise = createYdbQdrantClient({
+      defaultTenant: 'myapp',
+      endpoint: 'grpcs://lb.etn01g9tcilcon2mrt3h.ydb.mdb.yandexcloud.net:2135',
+      database: '/ru-central1/b1ge4v9r1l3h1q4njclp/etn01g9tcilcon2mrt3h',
+    });
   }
   return clientPromise;
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds `endpoint` and `database` parameters to three code examples in the README, but uses what appear to be real Yandex Cloud YDB credentials instead of placeholder values. The hardcoded credentials expose:
- Endpoint: `grpcs://lb.etn01g9tcilcon2mrt3h.ydb.mdb.yandexcloud.net:2135`
- Database: `/ru-central1/b1ge4v9r1l3h1q4njclp/etn01g9tcilcon2mrt3h`

**Critical Issues:**
- Real production/test credentials should never be committed to documentation
- These credentials are now publicly visible in the repository history
- All three examples (lines 88-89, 119-120, 144-145) contain the same real credentials

**Required Actions:**
- Replace with placeholder values matching the pattern already used elsewhere in the README (e.g., `grpcs://ydb.serverless.yandexcloud.net:2135` and `/ru-central1/<cloud>/<db>`)
- Rotate the exposed credentials if they provide access to sensitive data
- Review security practices for handling credentials in documentation

<h3>Confidence Score: 0/5</h3>


- This PR is unsafe to merge due to exposed production credentials
- Score of 0 reflects a critical security vulnerability: real YDB endpoint and database credentials are hardcoded in public documentation examples across three locations. This exposes potentially active infrastructure to unauthorized access.
- README.md requires immediate attention - all hardcoded credentials must be replaced with placeholders before merging

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| README.md | 1/5 | Added hardcoded YDB endpoint and database credentials to code examples - major security issue |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Repo as GitHub Repository
    participant Doc as README.md
    participant Users as Public Users

    Dev->>Doc: Add endpoint & database params to examples
    Note over Dev,Doc: Hardcodes real YDB credentials<br/>in 3 locations (lines 88-89, 119-120, 144-145)
    Dev->>Repo: Commit & push changes
    Repo->>Users: Public repository exposes credentials
    Note over Users: Real YDB endpoint and database path<br/>now visible to anyone
    Users-->>Repo: Potential unauthorized access risk
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->