### PR TITLE
feat: add healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ COPY --from=builder /usr/src/app/logo.svg ./logo.svg
 
 EXPOSE 8080
 
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD node -e "require('http').get('http://localhost:8080/health', (res) => process.exit(res.statusCode === 200 ? 0 : 1))" || exit 1
+
 CMD ["node", "--experimental-specifier-resolution=node", "--enable-source-maps", "dist/index.js"]
 
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Added Docker HEALTHCHECK instruction that polls the existing `/health` endpoint every 30 seconds with a 3-second timeout and 5-second start period.

- Added healthcheck configuration with 3 retry attempts before marking container unhealthy
- Healthcheck uses Node.js `http.get()` to request `localhost:8080/health`
- **Critical issue**: Error handling is missing - if the server is down, the healthcheck will timeout instead of failing fast

<h3>Confidence Score: 3/5</h3>


- This PR adds useful Docker healthcheck functionality but has a critical error handling flaw that affects failure detection speed
- Score reflects that the healthcheck configuration is reasonable and the `/health` endpoint already exists, but the implementation has a logic bug where connection errors cause timeouts instead of fast failures. This doesn't break functionality but degrades container orchestration responsiveness.
- The `Dockerfile` needs attention to fix the error handling in the healthcheck command

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| Dockerfile | 3/5 | Added Docker healthcheck with HTTP request to `/health` endpoint, but has a critical logic flaw with error handling |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Docker
    participant HealthCheck
    participant NodeProcess
    participant ExpressServer
    
    loop Every 30s (after 5s start period)
        Docker->>HealthCheck: Execute healthcheck command
        HealthCheck->>NodeProcess: node -e "require('http').get(...)"
        NodeProcess->>ExpressServer: HTTP GET localhost:8080/health
        alt Server responds 200
            ExpressServer-->>NodeProcess: 200 OK + {"status":"ok"}
            NodeProcess->>NodeProcess: process.exit(0)
            NodeProcess-->>Docker: Exit code 0 (healthy)
        else Server responds non-200
            ExpressServer-->>NodeProcess: Non-200 status
            NodeProcess->>NodeProcess: process.exit(1)
            NodeProcess-->>Docker: Exit code 1 (unhealthy)
        else Connection error (server down)
            NodeProcess->>NodeProcess: Request error (callback never called)
            NodeProcess->>NodeProcess: Hang until timeout (3s)
            NodeProcess-->>Docker: Timeout/exit 1 (unhealthy)
        end
        alt After 3 consecutive failures
            Docker->>Docker: Mark container unhealthy
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->