### PR TITLE
fix: docker badge and compose fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Notes
 - Minimal `docker-compose.yml` (for users/tools that prefer compose):
   - Service `ydb-qdrant` with `image: ghcr.io/astandrik/ydb-qdrant:latest`, `ports: ["8080:8080"]`, `env_file: [.env]`, env keys `YDB_ENDPOINT`, `YDB_DATABASE`, `YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS=/sa-key.json`, and a volume `${YDB_SA_KEY_PATH}:/sa-key.json:ro`.
 - Updating to a newer image when using compose (no rebuild):
-  - `docker compose pull ydb-qdrant && docker compose up -d ydb-qdrant` (or the `docker-compose` equivalents).
+  - `docker-compose pull ydb-qdrant && docker-compose up -d ydb-qdrant`.
 - For agents that need a Qdrant base URL, point them at `http://localhost:8080` when this container/compose stack is running.
 
 ## Data model

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/astandrik/ydb-qdrant/actions/workflows/ci-ydb-qdrant.yml/badge.svg)](https://github.com/astandrik/ydb-qdrant/actions/workflows/ci-ydb-qdrant.yml)
 [![npm version](https://img.shields.io/npm/v/ydb-qdrant.svg)](https://www.npmjs.com/package/ydb-qdrant)
+[![Docker Image](https://img.shields.io/badge/docker-ghcr.io%2Fastandrik%2Fydb--qdrant-blue?logo=docker)](https://github.com/users/astandrik/packages/container/package/ydb-qdrant)
 [![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)
 
 # YDB Qdrant-compatible Service
@@ -293,8 +294,8 @@ LOG_LEVEL=info
 - **Updating to a newer image with Compose** (no rebuild):
   - Pull the latest tag and restart the service:
     ```bash
-    docker compose pull ydb-qdrant   # or: docker-compose pull ydb-qdrant
-    docker compose up -d ydb-qdrant  # or: docker-compose up -d ydb-qdrant
+    docker-compose pull ydb-qdrant
+    docker-compose up -d ydb-qdrant
     ```
 
 - **Environment**: uses the same variables as documented in **Configure credentials** (`YDB_ENDPOINT`, `YDB_DATABASE`, one of the `YDB_*_CREDENTIALS` options, optional `PORT`/`LOG_LEVEL`).


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR standardizes Docker Compose command syntax and adds Docker registry badge. It changes `docker compose` to `docker-compose` (hyphenated form) in documentation for consistency with Docker Compose v1 syntax, and adds a badge linking to the container registry on GitHub Packages.

- Updated docker compose commands in `AGENTS.md` and `README.md` to use hyphenated `docker-compose` syntax
- Added Docker image badge to `README.md` linking to the ghcr.io container package

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The changes are purely documentation updates with no code changes. The docker-compose syntax standardization improves consistency, and the badge addition provides useful visibility into the Docker image availability. No functional changes or potential bugs introduced.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| AGENTS.md | 5/5 | Updated docker compose command syntax to use hyphenated form for consistency |
| README.md | 5/5 | Added Docker badge and standardized docker-compose command syntax |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Docs as Documentation Files
    participant Badge as Docker Badge
    participant Registry as ghcr.io Registry

    Dev->>Docs: Update docker compose syntax
    Note over Docs: AGENTS.md line 54<br/>README.md lines 297-298
    Docs->>Docs: Change "docker compose"<br/>to "docker-compose"
    
    Dev->>Badge: Add Docker image badge
    Note over Badge: README.md line 5
    Badge->>Registry: Link to package page
    Note over Registry: ghcr.io/astandrik/ydb-qdrant
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->