### PR TITLE
chore: coveralls

### DIFF
--- a/.github/workflows/ci-ydb-qdrant.yml
+++ b/.github/workflows/ci-ydb-qdrant.yml
@@ -11,9 +11,6 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
 
     steps:
       - name: Checkout
@@ -36,14 +33,12 @@ jobs:
       - name: Test (with coverage)
         run: npm run test:coverage
 
-      - name: Upload coverage to Codecov
+      - name: Upload coverage to Coveralls
         if: github.ref == 'refs/heads/main'
-        uses: codecov/codecov-action@v5
+        uses: coverallsapp/github-action@v2
         with:
-          files: ./coverage/lcov.info
-          flags: unittests
-          fail_ci_if_error: false
-          use_oidc: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./coverage/lcov.info
 
       - name: Build
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build](https://img.shields.io/github/actions/workflow/status/astandrik/ydb-qdrant/ci-ydb-qdrant.yml?branch=main&label=build)](https://github.com/astandrik/ydb-qdrant/actions/workflows/ci-ydb-qdrant.yml)
 [![Tests](https://img.shields.io/github/actions/workflow/status/astandrik/ydb-qdrant/ci-ydb-qdrant.yml?branch=main&label=tests)](https://github.com/astandrik/ydb-qdrant/actions/workflows/ci-ydb-qdrant.yml)
-[![Coverage](https://codecov.io/gh/astandrik/ydb-qdrant/branch/main/graph/badge.svg)](https://codecov.io/gh/astandrik/ydb-qdrant)
+[![Coverage](https://coveralls.io/repos/github/astandrik/ydb-qdrant/badge.svg?branch=main)](https://coveralls.io/github/astandrik/ydb-qdrant?branch=main)
 [![npm version](https://img.shields.io/npm/v/ydb-qdrant.svg)](https://www.npmjs.com/package/ydb-qdrant)
 [![Docker Image](https://img.shields.io/badge/docker-ghcr.io%2Fastandrik%2Fydb--qdrant-blue?logo=docker)](https://github.com/users/astandrik/packages/container/package/ydb-qdrant)
 [![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Migrated CI coverage reporting from Codecov to Coveralls and updated the coverage badge in README.

- Replaced `codecov/codecov-action@v5` with `coverallsapp/github-action@v2`
- Removed OIDC-specific permissions (`id-token: write`) and configuration (`use_oidc: true`)
- Simplified coverage upload configuration: `github-token` and `path-to-lcov` instead of multiple Codecov-specific parameters
- Updated README.md badge to point to Coveralls instead of Codecov

The changes are straightforward and properly configured. The vitest configuration already generates lcov reports at `./coverage/lcov.info`, which matches the workflow's `path-to-lcov` parameter. The `GITHUB_TOKEN` secret is automatically available in GitHub Actions and doesn't require manual configuration.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The changes are limited to CI configuration and documentation updates with no functional code changes. The migration from Codecov to Coveralls is properly configured with correct parameters that match the existing vitest coverage setup. No security concerns or breaking changes introduced.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/ci-ydb-qdrant.yml | 5/5 | Migrated from Codecov to Coveralls for coverage reporting, removed OIDC permissions, simplified configuration |
| README.md | 5/5 | Updated coverage badge URL from Codecov to Coveralls |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant Repo as Repository
    participant Tests as Test Suite
    participant Coveralls as Coveralls Service

    Note over GH,Coveralls: CI Workflow (main branch only)

    GH->>Repo: Checkout code
    GH->>GH: Setup Node.js 22
    GH->>Repo: Install dependencies (npm ci)
    GH->>Tests: Run lint
    GH->>Tests: Run typecheck
    GH->>Tests: Run tests with coverage
    Tests->>Repo: Generate ./coverage/lcov.info
    
    alt Coverage upload (main branch only)
        GH->>Coveralls: Upload coverage report
        Note over GH,Coveralls: uses: coverallsapp/github-action@v2<br/>with github-token and path-to-lcov
        Coveralls->>Coveralls: Process and store coverage data
    end
    
    GH->>Repo: Build project (npm run build)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->