### PR TITLE
fix: use actual badges

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -1,4 +1,4 @@
-name: CI ydb-qdrant
+name: Integration tests
 
 on:
   push:
@@ -9,40 +9,6 @@ on:
       - main
 
 jobs:
-  ci:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Lint
-        run: npm run lint
-
-      - name: Typecheck
-        run: npm run typecheck
-
-      - name: Test (with coverage)
-        run: npm run test:coverage
-
-      - name: Upload coverage to Coveralls
-        if: github.ref == 'refs/heads/main'
-        uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./coverage/lcov.info
-
-      - name: Build
-        run: npm run build
-
   integration_tests:
     name: YDB integration tests (local-ydb nightly)
     runs-on: ubuntu-latest
@@ -86,3 +52,5 @@ jobs:
           YDB_ENDPOINT: grpc://localhost:2136
           YDB_DATABASE: /local
           YDB_ANONYMOUS_CREDENTIALS: "1"
+
+

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,43 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test (with coverage)
+        run: npm run test:coverage
+
+      - name: Upload coverage to Coveralls
+        if: github.ref == 'refs/heads/main'
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./coverage/lcov.info
+
+

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <img src="https://ydb-qdrant.tech/logo.svg" alt="YDB Qdrant logo" height="56"> 
 
-[![Build](https://img.shields.io/github/actions/workflow/status/astandrik/ydb-qdrant/ci-ydb-qdrant.yml?branch=main&label=build)](https://github.com/astandrik/ydb-qdrant/actions/workflows/ci-ydb-qdrant.yml)
-[![Tests](https://img.shields.io/github/actions/workflow/status/astandrik/ydb-qdrant/ci-ydb-qdrant.yml?branch=main&label=tests)](https://github.com/astandrik/ydb-qdrant/actions/workflows/ci-ydb-qdrant.yml)
-[![Integration Tests](https://img.shields.io/github/actions/workflow/status/astandrik/ydb-qdrant/ci-ydb-qdrant.yml?branch=main&label=integration%20tests)](https://github.com/astandrik/ydb-qdrant/actions/workflows/ci-ydb-qdrant.yml)
+[![Build](https://img.shields.io/github/actions/workflow/status/astandrik/ydb-qdrant/ci-build.yml?branch=main&label=build)](https://github.com/astandrik/ydb-qdrant/actions/workflows/ci-build.yml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/astandrik/ydb-qdrant/ci-tests.yml?branch=main&label=tests)](https://github.com/astandrik/ydb-qdrant/actions/workflows/ci-tests.yml)
+[![Integration Tests](https://img.shields.io/github/actions/workflow/status/astandrik/ydb-qdrant/ci-integration.yml?branch=main&label=integration%20tests)](https://github.com/astandrik/ydb-qdrant/actions/workflows/ci-integration.yml)
 [![Coverage](https://coveralls.io/repos/github/astandrik/ydb-qdrant/badge.svg?branch=main)](https://coveralls.io/github/astandrik/ydb-qdrant?branch=main)
 [![npm version](https://img.shields.io/npm/v/ydb-qdrant.svg)](https://www.npmjs.com/package/ydb-qdrant)
 [![Docker Image](https://img.shields.io/badge/docker-ghcr.io%2Fastandrik%2Fydb--qdrant-blue?logo=docker)](https://github.com/users/astandrik/packages/container/package/ydb-qdrant)


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Refactored CI workflows from a single monolithic workflow (`ci-ydb-qdrant.yml`) into three separate workflows (`ci-build.yml`, `ci-tests.yml`, `ci-integration.yml`), and updated README.md badges to reference the new workflow files.

**Changes:**
- Split the original `ci-ydb-qdrant.yml` workflow into three focused workflows for better modularity and independent badge statuses
- Created `ci-build.yml` containing only the build job
- Created `ci-tests.yml` containing lint, typecheck, test coverage, and Coveralls upload
- Renamed `ci-ydb-qdrant.yml` to `ci-integration.yml` and removed the `ci` job, keeping only integration tests
- Updated three badge URLs in README.md to point to the new workflow files instead of the old monolithic workflow

**Impact:**
This change enables individual status tracking for each CI phase (build, tests, integration) through separate badges, providing better visibility into which specific step might be failing.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no issues
- The changes are straightforward workflow refactoring that splits a monolithic CI workflow into three focused workflows. All workflow configurations are correct, with proper job definitions, steps, and environment variables. The README badge URLs correctly reference the new workflow files. No functional logic changes were made, only organizational improvements.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/ci-build.yml | 5/5 | New workflow file created for build job, extracted from monolithic workflow |
| .github/workflows/ci-tests.yml | 5/5 | New workflow file created for tests job, extracted from monolithic workflow |
| .github/workflows/ci-integration.yml | 5/5 | Renamed and simplified workflow to only contain integration tests, removed other jobs |
| README.md | 5/5 | Updated badge URLs to reference new workflow files instead of monolithic ci-ydb-qdrant.yml |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub
    participant Build as Build Workflow
    participant Tests as Tests Workflow
    participant Integration as Integration Workflow
    participant README as README Badges
    
    Dev->>GH: Push to main/PR
    
    par Build Job
        GH->>Build: Trigger ci-build.yml
        Build->>Build: Checkout code
        Build->>Build: Setup Node 22
        Build->>Build: npm ci
        Build->>Build: npm run build
        Build->>README: Update Build badge status
    and Tests Job
        GH->>Tests: Trigger ci-tests.yml
        Tests->>Tests: Checkout code
        Tests->>Tests: Setup Node 22
        Tests->>Tests: npm ci
        Tests->>Tests: npm run lint
        Tests->>Tests: npm run typecheck
        Tests->>Tests: npm run test:coverage
        Tests->>Tests: Upload to Coveralls (main only)
        Tests->>README: Update Tests badge status
    and Integration Tests Job
        GH->>Integration: Trigger ci-integration.yml
        Integration->>Integration: Start YDB service
        Integration->>Integration: Checkout code
        Integration->>Integration: Setup Node 22
        Integration->>Integration: npm ci
        Integration->>Integration: Wait for YDB ready
        Integration->>Integration: npm run test:integration
        Integration->>README: Update Integration badge status
    end
    
    README->>Dev: Display individual workflow statuses
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->