### PR TITLE
chore: add docs of models and dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,53 @@ export async function searchDocuments(collection: string, queryEmbedding: number
 
 This pattern avoids running a separate HTTP service: vector search is executed directly against YDB via the shared `createYdbQdrantClient` instance, while the rest of your code works with plain TypeScript functions.
 
+## Recommended Vector Dimensions
+
+When creating a collection, you must specify the vector `size` matching your embedding model. Below are popular models with their dimensions and typical use cases:
+
+### Commercial API Models
+
+| Provider | Model | Dimensions | Use Cases |
+|----------|-------|------------|-----------|
+| **OpenAI** | `text-embedding-3-small` | 1536 (default, can reduce to 256-1536) | RAG, semantic search, general-purpose embeddings |
+| **OpenAI** | `text-embedding-3-large` | 3072 (default, can reduce to 256, 512, 1024, 1536, 3072) | High-accuracy RAG, multilingual tasks |
+| **OpenAI** | `text-embedding-ada-002` | 1536 | Legacy model, widely adopted |
+| **OpenAI** (Legacy) | `text-search-curie-doc-001` | 4096 | Legacy GPT-3 model, deprecated |
+| **OpenAI** (Legacy) | `text-search-davinci-doc-001` | 12288 | Legacy GPT-3 model, deprecated |
+| **Cohere** | `embed-v4.0` | 256, 512, 1024, 1536 (default) | Multimodal (text + image), RAG, enterprise search |
+| **Cohere** | `embed-english-v3.0` | 1024 | English text, semantic search, classification |
+| **Cohere** | `embed-multilingual-v3.0` | 1024 | 100+ languages, long-document retrieval, clustering |
+| **Google** | `gemini-embedding-001` | 3072 (configurable) | Multilingual, general-purpose, RAG |
+| **Google** | `text-embedding-004` | 768 | General-purpose text embeddings |
+| **Google** | `text-embedding-005` | 768 | Improved version of text-embedding-004 |
+| **Google** | `text-multilingual-embedding-002` | 768 | Multilingual text embeddings |
+
+### Open-Source Models (HuggingFace)
+
+| Model | Dimensions | Use Cases |
+|-------|------------|-----------|
+| `sentence-transformers/all-MiniLM-L6-v2` | 384 | Fast semantic search, low-resource environments |
+| `BAAI/bge-base-en-v1.5` | 768 | RAG, retrieval, English text |
+| `BAAI/bge-large-en-v1.5` | 1024 | High-accuracy RAG, English text |
+| `BAAI/bge-m3` | 1024 | Multilingual, dense/sparse/multi-vector |
+| `intfloat/e5-base-v2` | 768 | General retrieval, English text |
+| `intfloat/e5-large-v2` | 1024 | High-accuracy retrieval, English text |
+| `intfloat/e5-mistral-7b-instruct` | 4096 | High-dimensional embeddings, advanced RAG |
+| `nomic-ai/nomic-embed-text-v1` | 768 | General-purpose, open weights |
+
+### Choosing Dimensions
+
+- **Higher dimensions (1024-4096)**: Better semantic fidelity, higher storage/compute costs
+- **Lower dimensions (384-768)**: Faster queries, lower costs, suitable for many use cases
+- **Variable dimensions**: Some models (OpenAI v3, Cohere v4) allow dimension reduction with minimal accuracy loss
+- **Legacy models**: Older OpenAI GPT-3 models (Curie: 4096, Davinci: 12288) are deprecated but may still be in use
+
+**References:**
+- [OpenAI Embeddings Guide](https://platform.openai.com/docs/guides/embeddings)
+- [Cohere Embed Models](https://docs.cohere.com/docs/cohere-embed)
+- [Google Gemini Embeddings](https://ai.google.dev/gemini-api/docs/embeddings)
+- [HuggingFace Sentence Transformers](https://huggingface.co/sentence-transformers)
+
 ## Quick Start
 
 ### Use with IDE agents (Roo Code, Cline)


### PR DESCRIPTION
Closes https://github.com/astandrik/ydb-qdrant/issues/40

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds comprehensive documentation for vector dimensions across popular embedding models. The new "Recommended Vector Dimensions" section provides:

- Tables of commercial API models (OpenAI, Cohere, Google) with their dimensions and use cases
- Open-source models from HuggingFace with dimensions
- Guidance on choosing appropriate dimensions based on accuracy vs cost tradeoffs
- Links to official documentation from model providers

The documentation is well-structured, accurate, and helpful for users selecting embedding models for their vector search use cases. The content is purely additive and doesn't modify any existing functionality.

<h3>Confidence Score: 5/5</h3>


- This PR is completely safe to merge with zero risk
- The PR only adds documentation to the README.md file without touching any code, configuration, or dependencies. The information appears accurate and well-researched, with proper references to official documentation sources. There are no code changes that could introduce bugs or security issues.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| README.md | 5/5 | Added comprehensive vector dimensions documentation for popular embedding models (OpenAI, Cohere, Google, HuggingFace) with use cases and references |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant README as README.md
    participant Users as Documentation Users
    
    Dev->>README: Add "Recommended Vector Dimensions" section
    Dev->>README: Document OpenAI models (text-embedding-3-small, ada-002, etc.)
    Dev->>README: Document Cohere models (embed-v4.0, multilingual-v3.0, etc.)
    Dev->>README: Document Google models (gemini-embedding-001, text-embedding-004, etc.)
    Dev->>README: Document HuggingFace models (all-MiniLM-L6-v2, bge-*, e5-*, etc.)
    Dev->>README: Add "Choosing Dimensions" guidance
    Dev->>README: Add references to official documentation
    
    Note over README: Documentation content added<br/>No code changes
    
    Users->>README: Read vector dimension guidance
    Users->>README: Select appropriate embedding model
    Users->>README: Reference dimension values for createCollection
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->