### PR TITLE
fix: allow cors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1831,7 +1831,6 @@
       "resolved": "https://registry.npmjs.org/@yandex-cloud/nodejs-sdk/-/nodejs-sdk-2.9.0.tgz",
       "integrity": "sha512-vnVM/P7o5/LpnBLqfEk5f0qCxD12AA45e4i94apBNSY45Z539fMB6a0cHBwfZooF7ck2zqDXuX6mJX3VXdr7kA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@grpc/grpc-js": "^1.6.12",
         "abort-controller-x": "^0.4.1",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,11 +1,24 @@
 import express from "express";
-import type { Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
 import { collectionsRouter } from "./routes/collections.js";
 import { pointsRouter } from "./routes/points.js";
 import { requestLogger } from "./middleware/requestLogger.js";
+function allowCors(req: Request, res: Response, next: NextFunction): void {
+  res.header("Access-Control-Allow-Origin", "*");
+  res.header("Access-Control-Allow-Methods", "GET,OPTIONS");
+  res.header("Access-Control-Allow-Headers", "Content-Type, X-Tenant-Id");
+
+  if (req.method === "OPTIONS") {
+    res.sendStatus(204);
+    return;
+  }
+
+  next();
+}
 
 export function buildServer() {
   const app = express();
+  app.use(allowCors);
   app.use(express.json({ limit: "20mb" }));
   app.use(requestLogger);
   app.get("/health", (_req: Request, res: Response) =>


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Added CORS middleware to enable cross-origin requests and fixed `@yandex-cloud/nodejs-sdk` installation by removing incorrect peer dependency flag.

**Critical Issue:**
- CORS configuration only allows GET/OPTIONS methods but the API uses POST, PUT, and DELETE extensively (upsert points, create collections, delete operations)

**Security Consideration:**
- `Access-Control-Allow-Origin: *` permits requests from any domain

<h3>Confidence Score: 1/5</h3>


- This PR will break most API functionality due to incomplete CORS configuration
- The CORS middleware only allows GET and OPTIONS methods, but the API uses POST (search, query, delete points), PUT (create collections, upsert points), and DELETE (delete collections) extensively. All these operations will be blocked by CORS preflight checks, making the API largely non-functional for cross-origin requests
- src/server.ts requires immediate attention - the allowed methods list must be updated

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/server.ts | 1/5 | Added CORS middleware but only allows GET/OPTIONS - missing POST, PUT, DELETE used by the API |
| package-lock.json | 5/5 | Removed `peer: true` flag from `@yandex-cloud/nodejs-sdk` dependency to fix installation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant allowCors
    participant Express
    participant Router
    participant YDB

    Client->>allowCors: HTTP Request (any method)
    allowCors->>allowCors: Set CORS headers
    alt method is OPTIONS
        allowCors->>Client: 204 No Content
    else other methods
        allowCors->>Express: next()
        Express->>Express: Parse JSON body
        Express->>Express: Request logging
        Express->>Router: Route to handler
        Router->>YDB: Query/Update data
        YDB-->>Router: Result
        Router-->>Client: JSON response with CORS headers
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->