### PR TITLE
fix: gracefully handle vector mismatch errors

### DIFF
--- a/src/services/errors.ts
+++ b/src/services/errors.ts
@@ -3,6 +3,12 @@ export interface QdrantServiceErrorPayload {
   error: unknown;
 }
 
+export function isVectorDimensionMismatchError(err: unknown): err is Error {
+  return (
+    err instanceof Error && err.message.startsWith("Vector dimension mismatch")
+  );
+}
+
 export class QdrantServiceError extends Error {
   readonly statusCode: number;
   readonly payload: QdrantServiceErrorPayload;


### PR DESCRIPTION
Closes https://github.com/astandrik/ydb-qdrant/issues/24

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR improves error handling by catching vector dimension mismatch errors from the repository layer and converting them into user-friendly 400 Bad Request responses with descriptive error messages.

- Added `isVectorDimensionMismatchError()` type guard to identify vector dimension errors
- Wrapped `repoUpsertPoints()` and `repoSearchPoints()` calls in try-catch blocks
- Converted caught dimension mismatch errors to `QdrantServiceError` with 400 status code
- Added warning logs with context when dimension mismatches occur
- Added comprehensive test coverage for both upsert and search error scenarios

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no identified risks
- The changes follow existing error handling patterns, add proper logging, include comprehensive test coverage for both upsert and search operations, and maintain backward compatibility by only affecting error responses
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/services/errors.ts | 5/5 | Added `isVectorDimensionMismatchError` type guard to detect vector dimension mismatch errors |
| src/services/PointsService.ts | 5/5 | Added try-catch blocks in `upsertPoints` and `executeSearch` to catch vector dimension mismatch errors and convert them to 400 status responses |
| test/services/QdrantService.test.ts | 5/5 | Added comprehensive test coverage for vector dimension mismatch error handling in both upsert and search operations |
| test/routes/points.test.ts | 5/5 | Added test case to verify router correctly returns 400 status with error payload for vector dimension mismatch errors |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Router as points.ts Router
    participant Service as PointsService
    participant Repo as pointsRepo
    participant YDB as YDB Database

    Note over Client,YDB: Upsert Points Flow with Vector Dimension Mismatch

    Client->>Router: PUT /collections/:collection/points
    Router->>Service: upsertPoints(ctx, body)
    Service->>Service: Validate collection exists
    Service->>Service: Parse and validate request
    Service->>Repo: repoUpsertPoints(table, points, dimension, uid)
    Repo->>Repo: Check vector.length !== dimension
    Repo-->>Service: throw Error("Vector dimension mismatch...")
    Service->>Service: isVectorDimensionMismatchError(err)
    Service->>Service: logger.warn() with context
    Service-->>Router: throw QdrantServiceError(400, payload)
    Router->>Router: catch QdrantServiceError
    Router-->>Client: 400 {status: "error", error: message}

    Note over Client,YDB: Search Points Flow with Vector Dimension Mismatch

    Client->>Router: POST /collections/:collection/points/search
    Router->>Service: searchPoints(ctx, body)
    Service->>Service: normalizeSearchBodyForSearch(body)
    Service->>Service: executeSearch(ctx, normalized, "search")
    Service->>Service: Validate collection exists
    Service->>Service: Parse and validate search request
    Service->>Repo: repoSearchPoints(table, vector, top, ...)
    Repo->>Repo: Check queryVector.length !== dimension
    Repo-->>Service: throw Error("Vector dimension mismatch...")
    Service->>Service: isVectorDimensionMismatchError(err)
    Service->>Service: logger.warn() with context
    Service-->>Router: throw QdrantServiceError(400, payload)
    Router->>Router: catch QdrantServiceError
    Router-->>Client: 400 {status: "error", error: message}
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->