### PR TITLE
fix: add arm docker build

### DIFF
--- a/.github/workflows/docker-ydb-qdrant.yml
+++ b/.github/workflows/docker-ydb-qdrant.yml
@@ -35,6 +35,12 @@ jobs:
           VERSION="${TAG#ydb-qdrant-v}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
Closes https://github.com/astandrik/ydb-qdrant/issues/33

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds ARM64 platform support (`linux/arm64`) to the Docker build workflow, expanding from AMD64-only builds to multi-platform builds. However, **this change introduced a critical bug** - multi-platform Docker builds require QEMU emulation and Docker Buildx to be set up before the build step, which were not included in this PR.

**Key Changes:**
- Modified `platforms` from `linux/amd64` to `linux/amd64,linux/arm64` in the Docker build step

**Critical Issue:**
- The workflow would fail at build time because `docker/build-push-action@v6` cannot build ARM64 images without QEMU and Buildx setup
- This was subsequently fixed in PR #73, which added the required `docker/setup-qemu-action@v3` and `docker/setup-buildx-action@v3` steps

**Dependencies:**
The Dockerfile uses `node:22-alpine` base images, which support both AMD64 and ARM64 architectures. The Node.js dependencies in `package.json` appear to be platform-agnostic (no native bindings requiring special handling), making this a suitable candidate for multi-platform builds once the proper setup is in place.

<h3>Confidence Score: 2/5</h3>


- This PR introduced a critical bug that would cause workflow failures - DO NOT MERGE without the fixes from PR #73
- The change adds ARM64 platform support but omits the required QEMU and Docker Buildx setup steps, which would cause the GitHub Actions workflow to fail when attempting multi-platform builds. The docker/build-push-action@v6 requires these setup steps to emulate and build for non-native architectures. This is a fundamental requirement for multi-platform Docker builds that was overlooked.
- `.github/workflows/docker-ydb-qdrant.yml` requires QEMU and Buildx setup steps before the build action (fixed in PR #73)

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/docker-ydb-qdrant.yml | 2/5 | Added ARM64 platform support to Docker build without required QEMU and Buildx setup - this was a critical oversight fixed in PR #73 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Release
    participant Workflow as Workflow Runner
    participant Docker as Docker Build
    participant GHCR as GitHub Container Registry
    
    GH->>Workflow: Release published event
    Workflow->>Workflow: Checkout code
    Workflow->>Workflow: Login to GHCR
    Workflow->>Workflow: Extract version from tag
    Note over Workflow: ❌ MISSING: QEMU setup
    Note over Workflow: ❌ MISSING: Docker Buildx setup
    Workflow->>Docker: Build for linux/amd64,linux/arm64
    Docker--xWorkflow: ❌ FAIL: Cannot build ARM64 without QEMU
    Note over Workflow,GHCR: Build fails - no images pushed
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->