### PR TITLE
fix: build

### DIFF
--- a/Dockerfile.local-ydb
+++ b/Dockerfile.local-ydb
@@ -21,6 +21,7 @@ RUN set -eux; \
     echo "This image currently supports only x86_64/amd64"; \
     exit 1; \
   fi; \
+  apt-get update && apt-get install -y --no-install-recommends curl xz-utils && rm -rf /var/lib/apt/lists/*; \
   curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" -o /tmp/node.tar.xz; \
   mkdir -p /usr/local/lib/nodejs; \
   tar -xJf /tmp/node.tar.xz -C /usr/local/lib/nodejs; \


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixed Docker build failure by installing missing dependencies (`curl` and `xz-utils`) required for Node.js installation in the runner stage.

- Previously, the build failed because `curl` and `xz-utils` were not available in the YDB base image
- Added `apt-get` commands to install these tools before attempting to download and extract Node.js
- Properly cleaned up apt lists afterward to minimize image size

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a straightforward build fix that adds essential dependencies before using them. The implementation follows Docker best practices by combining commands, cleaning up apt lists, and using `--no-install-recommends` flag. No logical issues or security concerns identified.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| Dockerfile.local-ydb | 5/5 | Added missing dependencies (`curl` and `xz-utils`) required for Node.js installation in the runner stage |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Docker as Docker Build
    participant Runner as YDB Runner Stage
    participant APT as APT Package Manager
    participant NodeJS as Node.js Download

    Docker->>Runner: FROM ghcr.io/ydb-platform/local-ydb:stable-25-3
    Runner->>Runner: Check architecture (x86_64/amd64)
    Runner->>APT: apt-get update
    APT->>APT: Install curl and xz-utils
    APT->>Runner: Dependencies installed
    Runner->>Runner: Clean up /var/lib/apt/lists/*
    Runner->>NodeJS: curl Node.js v22.11.0 tarball
    NodeJS->>Runner: Download node.tar.xz
    Runner->>Runner: Extract tarball to /usr/local/lib/nodejs
    Runner->>Runner: Create symlinks for node, npm, npx
    Runner->>Runner: Install production dependencies (npm ci)
    Runner->>Runner: Copy build artifacts from builder stage
    Runner->>Docker: Image ready with YDB + Qdrant + Node.js
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->