### PR TITLE
fix: build 2

### DIFF
--- a/Dockerfile.local-ydb
+++ b/Dockerfile.local-ydb
@@ -21,7 +21,7 @@ RUN set -eux; \
     echo "This image currently supports only x86_64/amd64"; \
     exit 1; \
   fi; \
-  apt-get update && apt-get install -y --no-install-recommends curl xz-utils && rm -rf /var/lib/apt/lists/*; \
+  apt-get update && apt-get install -y --no-install-recommends ca-certificates curl xz-utils && rm -rf /var/lib/apt/lists/*; \
   curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" -o /tmp/node.tar.xz; \
   mkdir -p /usr/local/lib/nodejs; \
   tar -xJf /tmp/node.tar.xz -C /usr/local/lib/nodejs; \


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR fixes the Docker build by adding the `ca-certificates` package to the apt-get install command in `Dockerfile.local-ydb`.

- Added `ca-certificates` to enable SSL certificate verification when curl downloads Node.js from `https://nodejs.org`
- Without this package, curl cannot verify HTTPS certificates, causing the build to fail
- This is a follow-up to the previous build fix PR (#79)

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it's a minimal, targeted fix that adds a required system dependency.
- The change adds `ca-certificates` which is a standard and necessary package for HTTPS requests via curl. This is a well-understood fix for SSL certificate verification issues in Docker builds.
- No files require special attention.

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| Dockerfile.local-ydb | 5/5 | Added `ca-certificates` package to apt-get install to fix SSL certificate verification for curl when downloading Node.js from HTTPS URLs. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Docker as Docker Build
    participant APT as apt-get
    participant Curl as curl
    participant NodeJS as nodejs.org

    Docker->>APT: Install ca-certificates, curl, xz-utils
    APT-->>Docker: Packages installed
    Docker->>Curl: Download Node.js
    Curl->>NodeJS: HTTPS request (with SSL verification)
    NodeJS-->>Curl: Node.js tarball
    Curl-->>Docker: Download complete
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->