### PR TITLE
fix: build 4

### DIFF
--- a/Dockerfile.local-ydb
+++ b/Dockerfile.local-ydb
@@ -33,7 +33,7 @@ RUN set -eux; \
 ENV PATH="/usr/local/bin:${PATH}"
 
 COPY package*.json ./
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev --ignore-scripts
 COPY --from=builder /usr/src/app/dist ./dist
 COPY --from=builder /usr/src/app/README.md ./README.md
 COPY --from=builder /usr/src/app/LICENSE ./LICENSE


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Adds the `--ignore-scripts` flag to the `npm ci --omit=dev` command in the production stage of `Dockerfile.local-ydb`.

- Fixes Docker build failure caused by the `prepare` lifecycle script attempting to run `husky` during production dependency installation
- Since husky is a devDependency (excluded by `--omit=dev`) and no `.git` directory exists in the production container, the prepare script would fail without this flag
- This is a continuation of previous build fix PRs (#79, #81, #83) that addressed Node.js installation issues in the local-ydb Docker image

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it's a targeted, minimal fix for a Docker build issue
- The change adds a single standard npm flag to skip lifecycle scripts during production dependency installation. This is a well-understood pattern to avoid husky/prepare script failures in environments without git.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| Dockerfile.local-ydb | 5/5 | Added `--ignore-scripts` flag to `npm ci --omit=dev` to prevent husky prepare script from failing when installing production dependencies (husky is a devDependency and no .git directory exists). |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant DockerBuild as Docker Build
    participant NPM as npm ci
    participant Husky as Husky (prepare script)
    
    DockerBuild->>NPM: npm ci --omit=dev --ignore-scripts
    Note over NPM: Installs production deps only
    Note over NPM: Skips lifecycle scripts
    NPM-->>DockerBuild: Success (husky skipped)
    
    Note over DockerBuild: Without --ignore-scripts:
    DockerBuild->>NPM: npm ci --omit=dev
    NPM->>Husky: Run prepare script
    Husky--xNPM: Fails (husky not installed, no .git)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->