### PR TITLE
fix: run

### DIFF
--- a/docker/entrypoint-local-ydb-qdrant.sh
+++ b/docker/entrypoint-local-ydb-qdrant.sh
@@ -14,7 +14,7 @@ export MON_PORT="${YDB_LOCAL_MON_PORT}"
 
 start_local_ydb() {
   if [[ -f "/initialize_local_ydb" ]]; then
-    sh /initialize_local_ydb &
+    bash /initialize_local_ydb &
   else
     echo "initialize_local_ydb script not found; local YDB may not start correctly" >&2
   fi


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Changed shell executor from `sh` to `bash` when launching the `/initialize_local_ydb` script in the Docker entrypoint.

- Ensures consistency with the script's bash-only implementation (indicated by `#!/usr/bin/env bash` shebang and bash-specific features like `/dev/tcp`)
- Aligns with the inline comment stating "this script is bash-only"

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a trivial one-word fix that improves consistency. Changing `sh` to `bash` aligns with the script's declared bash-only nature and does not alter functionality or introduce new behavior
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| docker/entrypoint-local-ydb-qdrant.sh | 5/5 | Changed `sh` to `bash` for consistency with script's bash-only implementation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Container
    participant Entrypoint as entrypoint-local-ydb-qdrant.sh
    participant InitScript as /initialize_local_ydb
    participant YDB as Local YDB Server
    participant App as Node.js Application

    Container->>Entrypoint: Execute entrypoint
    Entrypoint->>Entrypoint: Set environment variables<br/>(GRPC_PORT, MON_PORT, etc)
    Entrypoint->>Entrypoint: start_local_ydb()
    Entrypoint->>InitScript: bash /initialize_local_ydb &<br/>(background process)
    InitScript->>YDB: Initialize and start YDB
    Entrypoint->>Entrypoint: wait_for_ydb()
    
    loop Retry up to 60 times
        Entrypoint->>YDB: Check TCP connection<br/>on port 2136
        alt Connection successful
            YDB-->>Entrypoint: Connection established
        else Connection failed
            Entrypoint->>Entrypoint: Wait 2 seconds
        end
    end
    
    alt YDB Ready
        Entrypoint->>App: exec node dist/index.js
        App->>YDB: Connect via grpc://localhost:2136
    else YDB Not Ready
        Entrypoint->>Container: Exit with error code 1
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->