### PR TITLE
fix: improve recall tests

### DIFF
--- a/.github/workflows/ci-recall.yml
+++ b/.github/workflows/ci-recall.yml
@@ -56,6 +56,8 @@ jobs:
         run: |
           MULTI=$(grep 'RECALL_MEAN_MULTI_TABLE' recall.log | tail -1 | awk '{print $2}')
           ONE=$(grep 'RECALL_MEAN_ONE_TABLE' recall.log | tail -1 | awk '{print $2}')
+          F1_MULTI=$(grep 'F1_MEAN_MULTI_TABLE' recall.log | tail -1 | awk '{print $2}')
+          F1_ONE=$(grep 'F1_MEAN_ONE_TABLE' recall.log | tail -1 | awk '{print $2}')
 
           if [ -z "$MULTI" ]; then
             echo "No multi_table recall value found in logs"
@@ -67,17 +69,31 @@ jobs:
             exit 1
           fi
 
+          if [ -z "$F1_MULTI" ]; then
+            echo "No multi_table F1 value found in logs"
+            exit 1
+          fi
+
+          if [ -z "$F1_ONE" ]; then
+            echo "No one_table F1 value found in logs"
+            exit 1
+          fi
+
           echo "mean_recall_multi=$MULTI" >> "$GITHUB_OUTPUT"
           echo "mean_recall_one=$ONE" >> "$GITHUB_OUTPUT"
+          echo "mean_f1_multi=$F1_MULTI" >> "$GITHUB_OUTPUT"
+          echo "mean_f1_one=$F1_ONE" >> "$GITHUB_OUTPUT"
 
       - name: Publish recall badge JSON
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           MULTI="${{ steps.recall.outputs.mean_recall_multi }}"
           ONE="${{ steps.recall.outputs.mean_recall_one }}"
+          F1_MULTI="${{ steps.recall.outputs.mean_f1_multi }}"
+          F1_ONE="${{ steps.recall.outputs.mean_f1_one }}"
 
-          if [ -z "$MULTI" ] || [ -z "$ONE" ]; then
-            echo "mean_recall_multi or mean_recall_one output is empty"
+          if [ -z "$MULTI" ] || [ -z "$ONE" ] || [ -z "$F1_MULTI" ] || [ -z "$F1_ONE" ]; then
+            echo "one of mean_recall_* or mean_f1_* outputs is empty"
             exit 1
           fi
 
@@ -94,6 +110,8 @@ jobs:
 
           COLOR_MULTI=$(color_for_value "$MULTI")
           COLOR_ONE=$(color_for_value "$ONE")
+          COLOR_F1_MULTI=$(color_for_value "$F1_MULTI")
+          COLOR_F1_ONE=$(color_for_value "$F1_ONE")
 
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
@@ -117,7 +135,23 @@ jobs:
           printf '  "color": "%s"\n' "$COLOR_ONE" >> recall-one-table.json
           printf '}\n' >> recall-one-table.json
 
-          git add recall-multi-table.json recall-one-table.json
+          # multi_table F1 badge JSON
+          printf '{\n' > f1-multi-table.json
+          printf '  "schemaVersion": 1,\n' >> f1-multi-table.json
+          printf '  "label": "F1 (multi_table)",\n' >> f1-multi-table.json
+          printf '  "message": "%.3f",\n' "$F1_MULTI" >> f1-multi-table.json
+          printf '  "color": "%s"\n' "$COLOR_F1_MULTI" >> f1-multi-table.json
+          printf '}\n' >> f1-multi-table.json
+
+          # one_table F1 badge JSON
+          printf '{\n' > f1-one-table.json
+          printf '  "schemaVersion": 1,\n' >> f1-one-table.json
+          printf '  "label": "F1 (one_table)",\n' >> f1-one-table.json
+          printf '  "message": "%.3f",\n' "$F1_ONE" >> f1-one-table.json
+          printf '  "color": "%s"\n' "$COLOR_F1_ONE" >> f1-one-table.json
+          printf '}\n' >> f1-one-table.json
+
+          git add recall-multi-table.json recall-one-table.json f1-multi-table.json f1-one-table.json
           git commit -m "Update recall badge [skip ci]" || echo "No changes to commit"
           git push origin recall-badges || echo "Failed to push recall-badges (likely from a fork PR)"
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 [![Recall (multi_table)](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astandrik/ydb-qdrant/recall-badges/recall-multi-table.json)](https://github.com/astandrik/ydb-qdrant/actions/workflows/ci-recall.yml)
 [![Recall (one_table)](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astandrik/ydb-qdrant/recall-badges/recall-one-table.json)](https://github.com/astandrik/ydb-qdrant/actions/workflows/ci-recall.yml)
+[![F1 (multi_table)](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astandrik/ydb-qdrant/recall-badges/f1-multi-table.json)](https://github.com/astandrik/ydb-qdrant/actions/workflows/ci-recall.yml)
+[![F1 (one_table)](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astandrik/ydb-qdrant/recall-badges/f1-one-table.json)](https://github.com/astandrik/ydb-qdrant/actions/workflows/ci-recall.yml)
 
 [![npm version](https://img.shields.io/npm/v/ydb-qdrant.svg)](https://www.npmjs.com/package/ydb-qdrant)
 [![Docker Image](https://img.shields.io/badge/docker-ghcr.io%2Fastandrik%2Fydb--qdrant-blue?logo=docker)](https://github.com/users/astandrik/packages/container/package/ydb-qdrant)

--- a/test/integration/YdbRealIntegration.one-table.test.ts
+++ b/test/integration/YdbRealIntegration.one-table.test.ts
@@ -15,6 +15,7 @@ import {
   MIN_MEAN_RECALL,
   buildGoldenDataset,
   computeRecall,
+  computeF1,
 } from "./helpers/recall-test-utils.js";
 
 const RNG_SEED = 4242;
@@ -55,6 +56,7 @@ describe("YDB integration with COLLECTION_STORAGE_MODE=one_table", () => {
     });
 
     const recalls: number[] = [];
+    const f1s: number[] = [];
 
     for (const query of queries) {
       const result = await client.searchPoints(collection, {
@@ -65,13 +67,17 @@ describe("YDB integration with COLLECTION_STORAGE_MODE=one_table", () => {
 
       const retrievedIds = (result.points ?? []).map((p) => p.id);
       const recall = computeRecall(query.relevantIds, retrievedIds);
+      const f1 = computeF1(query.relevantIds, retrievedIds);
       recalls.push(recall);
+      f1s.push(f1);
     }
 
     const meanRecall = recalls.reduce((sum, r) => sum + r, 0) / recalls.length;
+    const meanF1 = f1s.reduce((sum, v) => sum + v, 0) / f1s.length;
 
     // Used by CI to build a dynamic Shields.io badge with the actual recall value for one_table.
     console.log(`RECALL_MEAN_ONE_TABLE ${meanRecall.toFixed(4)}`);
+    console.log(`F1_MEAN_ONE_TABLE ${meanF1.toFixed(4)}`);
 
     expect(meanRecall).toBeGreaterThanOrEqual(MIN_MEAN_RECALL);
 

--- a/test/integration/YdbRecallIntegration.test.ts
+++ b/test/integration/YdbRecallIntegration.test.ts
@@ -6,6 +6,7 @@ import {
   MIN_MEAN_RECALL,
   buildGoldenDataset,
   computeRecall,
+  computeF1,
 } from "./helpers/recall-test-utils.js";
 
 const RNG_SEED = 42;
@@ -58,6 +59,7 @@ describe("YDB recall integration (multi_table, real YDB)", () => {
     const minMeanRecall = MIN_MEAN_RECALL;
 
     const recalls: number[] = [];
+    const f1s: number[] = [];
 
     for (const query of queries) {
       const result = await client.searchPoints(recallCollection, {
@@ -68,13 +70,17 @@ describe("YDB recall integration (multi_table, real YDB)", () => {
 
       const retrievedIds = (result.points ?? []).map((p) => p.id);
       const recall = computeRecall(query.relevantIds, retrievedIds);
+      const f1 = computeF1(query.relevantIds, retrievedIds);
       recalls.push(recall);
+      f1s.push(f1);
     }
 
     const meanRecall = recalls.reduce((sum, r) => sum + r, 0) / recalls.length;
+    const meanF1 = f1s.reduce((sum, v) => sum + v, 0) / f1s.length;
 
     // Used by CI to build a dynamic Shields.io badge with the actual recall value.
     console.log(`RECALL_MEAN_MULTI_TABLE ${meanRecall.toFixed(4)}`);
+    console.log(`F1_MEAN_MULTI_TABLE ${meanF1.toFixed(4)}`);
 
     expect(meanRecall).toBeGreaterThanOrEqual(minMeanRecall);
   }, 30000);

--- a/test/integration/helpers/recall-test-utils.ts
+++ b/test/integration/helpers/recall-test-utils.ts
@@ -13,8 +13,8 @@ export type GoldenQuery = {
 };
 
 export const RECALL_DIM = 16;
-export const CLUSTERS_COUNT = 4;
-export const POINTS_PER_CLUSTER = 100;
+export const CLUSTERS_COUNT = 16;
+export const POINTS_PER_CLUSTER = 80;
 export const RECALL_K = 80;
 export const MIN_MEAN_RECALL = 0.8;
 
@@ -73,6 +73,9 @@ export function buildGoldenDataset(seed: number): {
   return { points, queries };
 }
 
+// Metrics follow standard IR definitions (see Manning et al.,
+// "Introduction to Information Retrieval", Chapter 8: Evaluation in information retrieval —
+// https://nlp.stanford.edu/IR-book/pdf/08eval.pdf).
 export function computeRecall(
   relevantIds: string[],
   retrievedIds: string[]
@@ -80,4 +83,29 @@ export function computeRecall(
   const retrievedSet = new Set(retrievedIds);
   const found = relevantIds.filter((id) => retrievedSet.has(id)).length;
   return found / relevantIds.length;
+}
+
+export function computePrecisionAndRecall(
+  relevantIds: string[],
+  retrievedIds: string[]
+): { precision: number; recall: number } {
+  const retrievedSet = new Set(retrievedIds);
+  const found = relevantIds.filter((id) => retrievedSet.has(id)).length;
+
+  const precision = retrievedIds.length === 0 ? 0 : found / retrievedIds.length;
+  const recall = relevantIds.length === 0 ? 0 : found / relevantIds.length;
+
+  return { precision, recall };
+}
+
+export function computeF1(
+  relevantIds: string[],
+  retrievedIds: string[]
+): number {
+  const { precision, recall } = computePrecisionAndRecall(
+    relevantIds,
+    retrievedIds
+  );
+  if (precision === 0 && recall === 0) return 0;
+  return (2 * precision * recall) / (precision + recall);
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR enhances the recall testing infrastructure by adding F1 score metrics alongside the existing recall metrics. The changes include:

- **New evaluation metric**: Added F1 score computation functions (`computeF1`, `computePrecisionAndRecall`) to `recall-test-utils.ts` with proper academic reference to Manning et al.'s "Introduction to Information Retrieval"
- **Improved test dataset**: Increased the test dataset from 4 clusters with 100 points each (400 points) to 16 clusters with 80 points each (1280 points), providing more comprehensive coverage of vector search quality
- **CI/CD integration**: Extended the GitHub Actions workflow to extract F1 metrics from test output and publish them as dynamic badges alongside recall metrics
- **Documentation**: Added F1 score badges to the README for both `multi_table` and `one_table` storage modes

The F1 score provides a harmonic mean of precision and recall, offering a more balanced view of retrieval quality than recall alone. This is particularly valuable for understanding the trade-off between retrieving all relevant items (recall) and avoiding irrelevant items (precision).

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no issues found
- The changes are well-structured and follow best practices: (1) proper academic citation for metric definitions, (2) consistent implementation across both test files, (3) comprehensive CI/CD integration with validation checks, (4) backwards-compatible additions that don't break existing tests, and (5) mathematically correct implementations with proper edge case handling (division by zero)
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| test/integration/helpers/recall-test-utils.ts | 5/5 | Added F1, precision, and recall computation functions with proper academic reference; increased test dataset size (16 clusters x 80 points) |
| test/integration/YdbRecallIntegration.test.ts | 5/5 | Added F1 metric computation and logging for multi_table mode tests alongside existing recall metrics |
| test/integration/YdbRealIntegration.one-table.test.ts | 5/5 | Added F1 metric computation and logging for one_table mode tests alongside existing recall metrics |
| .github/workflows/ci-recall.yml | 5/5 | Extended CI workflow to extract F1 metrics from test logs and publish them as dynamic badges alongside recall metrics |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as Test Runner
    participant Utils as recall-test-utils
    participant Multi as YdbRecallIntegration
    participant One as YdbRealIntegration
    participant CI as GitHub Actions
    participant Badge as Badge JSON

    Test->>Utils: buildGoldenDataset(seed)
    Utils-->>Test: {points, queries}
    
    Test->>Multi: Run multi_table tests
    Multi->>Utils: computeRecall(relevant, retrieved)
    Utils-->>Multi: recall score
    Multi->>Utils: computeF1(relevant, retrieved)
    Utils->>Utils: computePrecisionAndRecall()
    Utils-->>Multi: F1 score
    Multi->>Multi: console.log RECALL_MEAN_MULTI_TABLE
    Multi->>Multi: console.log F1_MEAN_MULTI_TABLE
    
    Test->>One: Run one_table tests
    One->>Utils: computeRecall(relevant, retrieved)
    Utils-->>One: recall score
    One->>Utils: computeF1(relevant, retrieved)
    Utils->>Utils: computePrecisionAndRecall()
    Utils-->>One: F1 score
    One->>One: console.log RECALL_MEAN_ONE_TABLE
    One->>One: console.log F1_MEAN_ONE_TABLE
    
    CI->>CI: Extract metrics with grep/awk
    CI->>CI: Validate all metrics present
    CI->>CI: Compute color for each metric
    CI->>Badge: Generate recall-multi-table.json
    CI->>Badge: Generate recall-one-table.json
    CI->>Badge: Generate f1-multi-table.json
    CI->>Badge: Generate f1-one-table.json
    CI->>CI: git commit & push to recall-badges branch
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->