### PR TITLE
fix: add link

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,3 +516,4 @@ For broader Qdrant API coverage, extend routes in `src/routes/*`.
 - YQL functions index: https://ydb.tech/docs/en/yql/reference/functions/
 - ydb-sdk (Node.js): https://github.com/ydb-platform/ydb-nodejs-sdk
 - YDB Cloud (endpoints, auth): https://cloud.yandex.com/en/docs/ydb/
+- IR evaluation (precision/recall/F1, MAP, nDCG): [Manning et al., *Introduction to Information Retrieval*, Chapter 8](https://nlp.stanford.edu/IR-book/pdf/08eval.pdf)


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Added a reference link to Manning et al.'s *Introduction to Information Retrieval* (Chapter 8 on evaluation metrics) to the References section. This provides documentation for the precision, recall, F1, MAP, and nDCG metrics used in the recent recall testing implementation (PRs #94 and #96).

<h3>Confidence Score: 5/5</h3>


- This PR is completely safe to merge with no risk
- This is a documentation-only change that adds a single academic reference link to the README. No code changes, no functional changes, and no potential for runtime issues. The link correctly references a well-known textbook chapter on IR evaluation metrics that aligns with the project's recent recall testing features.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| README.md | 5/5 | Added reference link for information retrieval evaluation metrics in the References section |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant README as README.md
    participant Refs as References Section
    
    Dev->>README: Add reference link
    Dev->>Refs: Append IR evaluation textbook link
    Note over Refs: Manning et al., Chapter 8<br/>(precision/recall/F1, MAP, nDCG)
    README-->>Dev: Documentation updated
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->