### PR TITLE
chore: small docs improve

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,23 @@ For full tables of popular embedding models and their dimensions, see [docs/vect
 - API key optional (not enforced)
 - Full control and privacy
 
+**Option 3: All-in-one local YDB + ydb-qdrant (Docker)**
+
+Run a single container that includes both YDB and ydb-qdrant (no external YDB required):
+
+```bash
+docker run -d --name ydb-qdrant-local \
+  -p 8080:8080 \
+  -p 8765:8765 \
+  ghcr.io/astandrik/ydb-qdrant-local:latest
+```
+
+- HTTP API available at `http://localhost:8080`
+- YDB Embedded UI at `http://localhost:8765`
+- No credentials or env vars needed for local dev
+
+For detailed configuration and env tuning, see [docs/deployment-and-docker.md](docs/deployment-and-docker.md).
+
 ### cURL smoke test (Self-hosted)
 ```bash
 # 1) Install & run
@@ -263,7 +280,7 @@ docker run -d --name ydb-qdrant \
   ghcr.io/astandrik/ydb-qdrant:latest
 ```
 
-For full deployment options (local builds, all-in-one image, Docker Compose, Apple Silicon notes), see [docs/deployment-and-docker.md](docs/deployment-and-docker.md).
+For full deployment options (standalone image, all-in-one `ydb-qdrant-local`, Docker Compose, Apple Silicon notes), see [docs/deployment-and-docker.md](docs/deployment-and-docker.md).
 
 
 ## API Reference

--- a/docs/deployment-and-docker.md
+++ b/docs/deployment-and-docker.md
@@ -1,6 +1,6 @@
 ## Deployment and Docker
 
-This project provides multiple options for running the YDB Qdrant-compatible service via Docker.
+This document covers both the **standalone** `ydb-qdrant` image (connects to an external YDB) and the **all-in-one** `ydb-qdrant-local` image (includes a local YDB inside the container).
 
 ### Standalone HTTP Server (Published Image)
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Adds documentation for the new all-in-one `ydb-qdrant-local` Docker image that bundles both YDB and ydb-qdrant in a single container for simplified local development.

**Key changes:**
- Adds "Option 3" to README.md with docker run command for `ghcr.io/astandrik/ydb-qdrant-local:latest`
- Clarifies that the all-in-one image exposes ports 8080 (HTTP API) and 8765 (YDB Embedded UI)
- Updates introductory text in `deployment-and-docker.md` to distinguish between standalone and all-in-one images
- Maintains consistent cross-references between README and deployment docs

The changes are purely additive documentation updates with clear, accurate information about the new deployment option.

<h3>Confidence Score: 5/5</h3>


- This PR is completely safe to merge - documentation-only changes with no code modifications
- Perfect score reflects that this is a low-risk documentation update that adds clear, well-formatted information about a new deployment option. No code changes, no breaking changes, no security concerns. The additions improve user experience by documenting the all-in-one Docker image.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| README.md | 5/5 | Adds clear documentation for the new all-in-one `ydb-qdrant-local` Docker image option with proper formatting and cross-references |
| docs/deployment-and-docker.md | 5/5 | Updates intro text to clarify distinction between standalone and all-in-one Docker images |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant README.md
    participant deployment-and-docker.md
    
    User->>README.md: Read deployment options
    README.md->>README.md: Add "Option 3: All-in-one local YDB + ydb-qdrant"
    README.md->>README.md: Add docker run command for ydb-qdrant-local
    README.md->>README.md: List key features (ports 8080, 8765, no credentials)
    README.md->>deployment-and-docker.md: Reference detailed docs link
    README.md->>README.md: Update deployment section text (standalone → all-in-one)
    
    User->>deployment-and-docker.md: Navigate to detailed docs
    deployment-and-docker.md->>deployment-and-docker.md: Update intro to clarify standalone vs all-in-one
    deployment-and-docker.md->>User: Return comprehensive deployment guidance
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->