### PR TITLE
feat: save database data between restarts/updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,7 @@ Collection created automatically on first use.
 - Purpose: single-container local dev/demo with both YDB (Embedded UI on 8765) and ydb-qdrant HTTP API (8080) inside.
 - Typical run:
   - `docker run -d --name ydb-qdrant-local -p 8080:8080 -p 8765:8765 ghcr.io/astandrik/ydb-qdrant-local:latest`
+- The typical run command is ephemeral (data lives inside the container filesystem). For an example that keeps embedded YDB data across restarts, see the “Persistence across restarts (optional)” subsection in `docs/deployment-and-docker.md`.
 - YDB config (env, all optional):
   - `YDB_LOCAL_GRPC_PORT` (default `2136`), `YDB_LOCAL_MON_PORT` (default `8765`), `YDB_DATABASE` (default `/local`), `YDB_ANONYMOUS_CREDENTIALS` (default `1`), `YDB_USE_IN_MEMORY_PDISKS`, `YDB_LOCAL_SURVIVE_RESTART`, `YDB_DEFAULT_LOG_LEVEL`, `YDB_FEATURE_FLAGS`, `YDB_ENABLE_COLUMN_TABLES`, `YDB_KAFKA_PROXY_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`.
 - ydb-qdrant config (env, same semantics as standalone image):

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ docker run -d --name ydb-qdrant \
   ghcr.io/astandrik/ydb-qdrant:latest
 ```
 
-For full deployment options (standalone image, all-in-one `ydb-qdrant-local`, Docker Compose, Apple Silicon notes), see [docs/deployment-and-docker.md](docs/deployment-and-docker.md).
+For full deployment options (local builds, all-in-one image, Docker Compose, Apple Silicon notes), see [docs/deployment-and-docker.md](docs/deployment-and-docker.md) — including an optional “Persistence across restarts” example for the `ydb-qdrant-local` image when you want embedded YDB data to survive container restarts.
 
 
 ## API Reference


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds documentation for persisting embedded YDB data across container restarts when using the `ydb-qdrant-local` Docker image. Previously, the quick-start examples used ephemeral storage (data lost on restart), which is appropriate for development but not for users wanting to preserve collections and points.

**Key additions:**
- New "Persistence across restarts (optional)" subsection in `docs/deployment-and-docker.md` with three persistence patterns: host directory mount, Docker named volume, and Docker Compose
- Instructions for setting `YDB_LOCAL_SURVIVE_RESTART=1` and mounting `/ydb_data` volume
- Verification steps to test that data survives restarts
- Cross-references in `AGENTS.md` and `README.md` pointing users to the persistence documentation

The documentation is clear, accurate, and well-structured. All examples are syntactically correct and follow Docker best practices.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk - it only adds documentation
- Documentation-only change that improves user experience by addressing a common need (data persistence). No code changes, no runtime impact, and all examples are technically accurate. The content properly explains the difference between ephemeral and persistent storage patterns.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| AGENTS.md | 5/5 | Added reference to persistence documentation for ephemeral container use case |
| README.md | 5/5 | Updated deployment link description to mention persistence across restarts |
| docs/deployment-and-docker.md | 5/5 | Added comprehensive persistence section with Docker volume examples and verification steps |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Docker
    participant Container as ydb-qdrant-local
    participant YDB as Embedded YDB
    participant Volume as /ydb_data

    Note over User,Volume: Without persistence (ephemeral - original behavior)
    User->>Docker: docker run (no volume)
    Docker->>Container: Start container
    Container->>YDB: Initialize YDB in memory/container filesystem
    YDB-->>Container: Ready
    User->>Container: Create collections, upsert points
    Container->>YDB: Store in container filesystem
    User->>Docker: docker restart
    Docker->>Container: Restart container
    Note over YDB: Data lost - YDB reinitializes
    
    Note over User,Volume: With persistence (new documentation)
    User->>Docker: docker run -e YDB_LOCAL_SURVIVE_RESTART=1<br/>-v ./ydb_data:/ydb_data
    Docker->>Volume: Mount host directory to /ydb_data
    Docker->>Container: Start with volume
    Container->>YDB: Start with YDB_LOCAL_SURVIVE_RESTART=1
    YDB->>Volume: Use /ydb_data for storage
    YDB-->>Container: Ready
    User->>Container: Create collections, upsert points
    Container->>YDB: Store data
    YDB->>Volume: Persist to /ydb_data
    User->>Docker: docker restart ydb-qdrant-local
    Docker->>Container: Restart (volume persists)
    Container->>YDB: Start with YDB_LOCAL_SURVIVE_RESTART=1
    YDB->>Volume: Load existing data from /ydb_data
    YDB-->>Container: Ready with preserved data
    User->>Container: Query collection
    Container->>YDB: Fetch points
    YDB->>Volume: Read from /ydb_data
    YDB-->>Container: Return preserved data
    Container-->>User: Points still present
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->