### PR TITLE
feat: save database data between restarts/updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,7 @@ Collection created automatically on first use.
 - Purpose: single-container local dev/demo with both YDB (Embedded UI on 8765) and ydb-qdrant HTTP API (8080) inside.
 - Typical run:
   - `docker run -d --name ydb-qdrant-local -p 8080:8080 -p 8765:8765 ghcr.io/astandrik/ydb-qdrant-local:latest`
+- The typical run command is ephemeral (data lives inside the container filesystem). For an example that keeps embedded YDB data across restarts, see the “Persistence across restarts (optional)” subsection in `docs/deployment-and-docker.md`.
 - YDB config (env, all optional):
   - `YDB_LOCAL_GRPC_PORT` (default `2136`), `YDB_LOCAL_MON_PORT` (default `8765`), `YDB_DATABASE` (default `/local`), `YDB_ANONYMOUS_CREDENTIALS` (default `1`), `YDB_USE_IN_MEMORY_PDISKS`, `YDB_LOCAL_SURVIVE_RESTART`, `YDB_DEFAULT_LOG_LEVEL`, `YDB_FEATURE_FLAGS`, `YDB_ENABLE_COLUMN_TABLES`, `YDB_KAFKA_PROXY_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`.
 - ydb-qdrant config (env, same semantics as standalone image):

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ docker run -d --name ydb-qdrant \
   ghcr.io/astandrik/ydb-qdrant:latest
 ```
 
-For full deployment options (standalone image, all-in-one `ydb-qdrant-local`, Docker Compose, Apple Silicon notes), see [docs/deployment-and-docker.md](docs/deployment-and-docker.md).
+For full deployment options (local builds, all-in-one image, Docker Compose, Apple Silicon notes), see [docs/deployment-and-docker.md](docs/deployment-and-docker.md) — including an optional “Persistence across restarts” example for the `ydb-qdrant-local` image when you want embedded YDB data to survive container restarts.
 
 
 ## API Reference


### PR DESCRIPTION
Closes https://github.com/astandrik/ydb-qdrant/issues/93

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds documentation for persisting YDB data across container restarts in the `ydb-qdrant-local` Docker image. The changes guide users on how to configure volume mounts and the `YDB_LOCAL_SURVIVE_RESTART` environment variable to prevent data loss.

**Key additions:**
- Comprehensive "Persistence across restarts" subsection in `docs/deployment-and-docker.md` with examples for host directories, Docker-managed volumes, and Docker Compose
- Clear explanation of the `YDB_LOCAL_SURVIVE_RESTART=1` flag and `-v` volume mount syntax
- Step-by-step verification instructions to test persistence behavior
- Cross-references added in `AGENTS.md` and `README.md` pointing users to the new documentation

The documentation is well-structured, accurate, and addresses issue #93. No code changes were made.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- This is a documentation-only PR with no code changes. The added documentation is accurate, well-written, follows existing formatting conventions, and correctly addresses the issue. The Docker volume and environment variable usage is standard and correctly documented.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| AGENTS.md | 5/5 | Added single-line reference to persistence documentation in the all-in-one Docker image section |
| README.md | 5/5 | Updated deployment documentation link description to mention persistence across restarts |
| docs/deployment-and-docker.md | 5/5 | Added comprehensive persistence section with Docker volume examples, Docker Compose config, and verification steps |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Docker
    participant Container as ydb-qdrant-local
    participant YDB as Embedded YDB
    participant Volume as Host Volume/Docker Volume

    Note over User,Volume: Scenario 1: Ephemeral (Default)
    User->>Docker: docker run -p 8080:8080 -p 8765:8765<br/>ydb-qdrant-local
    Docker->>Container: Start container
    Container->>YDB: Initialize YDB (in-memory/container filesystem)
    User->>Container: Create collection & upsert points
    Container->>YDB: Store data
    User->>Docker: docker restart
    Docker->>Container: Restart container
    Container->>YDB: Reinitialize (data lost)
    
    Note over User,Volume: Scenario 2: Persistent (With Volume)
    User->>Docker: docker run -e YDB_LOCAL_SURVIVE_RESTART=1<br/>-v /path/ydb_data:/ydb_data<br/>ydb-qdrant-local
    Docker->>Volume: Mount volume at /ydb_data
    Docker->>Container: Start container
    Container->>YDB: Initialize YDB with /ydb_data
    YDB->>Volume: Write data to mounted volume
    User->>Container: Create collection & upsert points
    Container->>YDB: Store data
    YDB->>Volume: Persist to /ydb_data
    User->>Docker: docker restart or recreate
    Docker->>Volume: Remount same volume
    Docker->>Container: Start container
    Container->>YDB: Reuse existing data in /ydb_data
    YDB->>Volume: Read persisted data
    User->>Container: Query collection
    Container->>YDB: Retrieve data
    YDB->>Volume: Read from /ydb_data
    Container-->>User: Return previously inserted points
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->