### PR TITLE
fix: fix license

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "zod"
   ],
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "description": "Qdrant-compatible Node.js/TypeScript API that stores/searches embeddings in YDB using single-phase top-k vector search with an automatic vector index and table-scan fallback.",
   "type": "module",
   "publishConfig": {


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR corrects the license field in `package.json` from ISC to Apache-2.0, aligning it with the actual Apache License 2.0 file that already exists in the repository. This is a purely administrative change that ensures the package metadata accurately reflects the project's licensing terms.

- Changed `license` field from "ISC" to "Apache-2.0" in `package.json`
- No functional code changes
- Aligns package.json with the existing LICENSE file in the repository

<h3>Confidence Score: 5/5</h3>


- This PR is completely safe to merge with zero risk
- This is a trivial metadata correction that changes a single string value in package.json to match the actual license file. There are no code changes, no logic changes, and no potential for introducing bugs or breaking changes
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| package.json | 5/5 | Updated license field from ISC to Apache-2.0 to match the existing LICENSE file |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Repo as Repository
    participant NPM as NPM Registry
    
    Note over Dev,Repo: License Metadata Correction
    
    Dev->>Repo: Update package.json license field
    Note over Repo: Change "ISC" to "Apache-2.0"
    
    Dev->>Repo: Commit change
    Note over Repo: License now matches LICENSE file
    
    Repo->>NPM: Publish with correct license metadata
    Note over NPM: Package shows Apache-2.0 license
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->