### PR TITLE
fix: container restarts

### DIFF
--- a/docker/entrypoint-local-ydb-qdrant.sh
+++ b/docker/entrypoint-local-ydb-qdrant.sh
@@ -54,7 +54,7 @@ monitor_ydb() {
       echo "Embedded YDB not reachable on ${host}:${port} (${failures}/${max_failures})" >&2
       if [ "${failures}" -ge "${max_failures}" ]; then
         echo "Embedded YDB unreachable for too long; exiting to trigger container restart" >&2
-        kill 1 || exit 1
+        kill -KILL 1 || exit 1
       fi
     fi
     sleep "${interval}"


### PR DESCRIPTION
https://github.com/astandrik/ydb-qdrant/issues/104

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Changed the YDB monitoring script to use SIGKILL instead of SIGTERM when terminating the container process after repeated health check failures. This ensures the container exits reliably when the embedded YDB becomes unresponsive, allowing Docker's restart policy to properly restart the container for self-healing.

**Key changes:**
- Modified `docker/entrypoint-local-ydb-qdrant.sh:57` from `kill 1` to `kill -KILL 1`
- This addresses the issue where PID 1 in Docker containers ignores SIGTERM by default unless explicitly handled
- The SIGKILL signal ensures immediate termination, triggering container restart when YDB health checks fail
- Works in conjunction with the self-healing feature introduced in PR #105

**Impact:**
- Improved container reliability for the `ydb-qdrant-local` image
- Ensures Docker restart policies work correctly when embedded YDB fails
- No changes to external behavior or API

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a single-line fix that correctly addresses a container restart issue by using SIGKILL instead of SIGTERM. The change is well-understood: PID 1 in Docker containers requires SIGKILL for reliable termination since it ignores SIGTERM by default. The fallback `|| exit 1` ensures the script exits even if the kill command fails. This is a standard pattern for Docker self-healing containers
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| docker/entrypoint-local-ydb-qdrant.sh | 4/5 | Changed signal from SIGTERM to SIGKILL when terminating PID 1 to forcefully exit the container when YDB monitoring fails |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Docker
    participant EntryScript as Entrypoint Script (PID 1)
    participant LocalYDB as Local YDB Process
    participant Monitor as YDB Monitor (Background)
    participant NodeJS as Node.js App (PID 1)
    
    Docker->>EntryScript: Start container
    EntryScript->>LocalYDB: start_local_ydb() - Launch YDB in background
    EntryScript->>EntryScript: wait_for_ydb() - Wait for YDB TCP port
    
    alt YDB starts successfully
        LocalYDB-->>EntryScript: Port 2136 accepting connections
        EntryScript->>Monitor: Launch monitor_ydb in background
        EntryScript->>NodeJS: exec node (replaces PID 1)
        
        loop Every 10 seconds
            Monitor->>LocalYDB: Check TCP connectivity on port 2136
            alt YDB responding
                LocalYDB-->>Monitor: Connection successful
                Monitor->>Monitor: Reset failure counter
            else YDB not responding
                LocalYDB--xMonitor: Connection failed
                Monitor->>Monitor: Increment failure counter
                
                alt Failures >= max_failures (5)
                    Monitor->>NodeJS: kill -KILL 1 (SIGKILL to PID 1)
                    NodeJS-->>Docker: Process exits
                    Docker->>EntryScript: Restart container (restart policy)
                end
            end
        end
    else YDB fails to start
        EntryScript->>EntryScript: Timeout after 60 retries
        EntryScript->>Docker: exit 1
        Docker->>EntryScript: Restart container (restart policy)
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->