### PR TITLE
feat: include user-agent to collection name

### DIFF
--- a/src/routes/collections.ts
+++ b/src/routes/collections.ts
@@ -18,6 +18,7 @@ collectionsRouter.put(
         tenant: req.header("X-Tenant-Id") ?? undefined,
         collection: String(req.params.collection),
         apiKey: req.header("api-key") ?? undefined,
+        userAgent: req.header("User-Agent") ?? undefined,
       });
       res.json({ status: "ok", result });
     } catch (err: unknown) {
@@ -38,6 +39,7 @@ collectionsRouter.put("/:collection", async (req: Request, res: Response) => {
         tenant: req.header("X-Tenant-Id") ?? undefined,
         collection: String(req.params.collection),
         apiKey: req.header("api-key") ?? undefined,
+        userAgent: req.header("User-Agent") ?? undefined,
       },
       req.body
     );
@@ -58,6 +60,7 @@ collectionsRouter.get("/:collection", async (req: Request, res: Response) => {
       tenant: req.header("X-Tenant-Id") ?? undefined,
       collection: String(req.params.collection),
       apiKey: req.header("api-key") ?? undefined,
+      userAgent: req.header("User-Agent") ?? undefined,
     });
     res.json({ status: "ok", result });
   } catch (err: unknown) {
@@ -78,6 +81,7 @@ collectionsRouter.delete(
         tenant: req.header("X-Tenant-Id") ?? undefined,
         collection: String(req.params.collection),
         apiKey: req.header("api-key") ?? undefined,
+        userAgent: req.header("User-Agent") ?? undefined,
       });
       res.json({ status: "ok", result });
     } catch (err: unknown) {

--- a/src/routes/points.ts
+++ b/src/routes/points.ts
@@ -18,6 +18,7 @@ pointsRouter.put("/:collection/points", async (req: Request, res: Response) => {
         tenant: req.header("X-Tenant-Id") ?? undefined,
         collection: String(req.params.collection),
         apiKey: req.header("api-key") ?? undefined,
+        userAgent: req.header("User-Agent") ?? undefined,
       },
       req.body
     );
@@ -41,6 +42,7 @@ pointsRouter.post(
           tenant: req.header("X-Tenant-Id") ?? undefined,
           collection: String(req.params.collection),
           apiKey: req.header("api-key") ?? undefined,
+          userAgent: req.header("User-Agent") ?? undefined,
         },
         req.body
       );
@@ -65,6 +67,7 @@ pointsRouter.post(
           tenant: req.header("X-Tenant-Id") ?? undefined,
           collection: String(req.params.collection),
           apiKey: req.header("api-key") ?? undefined,
+          userAgent: req.header("User-Agent") ?? undefined,
         },
         req.body
       );
@@ -90,6 +93,7 @@ pointsRouter.post(
           tenant: req.header("X-Tenant-Id") ?? undefined,
           collection: String(req.params.collection),
           apiKey: req.header("api-key") ?? undefined,
+          userAgent: req.header("User-Agent") ?? undefined,
         },
         req.body
       );
@@ -114,6 +118,7 @@ pointsRouter.post(
           tenant: req.header("X-Tenant-Id") ?? undefined,
           collection: String(req.params.collection),
           apiKey: req.header("api-key") ?? undefined,
+          userAgent: req.header("User-Agent") ?? undefined,
         },
         req.body
       );

--- a/src/services/CollectionService.shared.ts
+++ b/src/services/CollectionService.shared.ts
@@ -5,6 +5,7 @@ import {
   tableNameFor as tableNameForInternal,
   uidFor as uidForInternal,
   hashApiKey,
+  hashUserAgent,
 } from "../utils/tenant.js";
 
 export interface NormalizedCollectionContextLike {
@@ -23,7 +24,8 @@ export function uidFor(tenantId: string, collection: string): string {
 export function normalizeCollectionContextShared(
   tenant: string | undefined,
   collection: string,
-  apiKey?: string
+  apiKey?: string,
+  userAgent?: string
 ): {
   tenant: string;
   collection: string;
@@ -31,7 +33,12 @@ export function normalizeCollectionContextShared(
 } {
   const normalizedTenant = sanitizeTenantId(tenant);
   const apiKeyHash = hashApiKey(apiKey);
-  const normalizedCollection = sanitizeCollectionName(collection, apiKeyHash);
+  const userAgentHash = hashUserAgent(userAgent);
+  const normalizedCollection = sanitizeCollectionName(
+    collection,
+    apiKeyHash,
+    userAgentHash
+  );
   const metaKey = metaKeyFor(normalizedTenant, normalizedCollection);
   return {
     tenant: normalizedTenant,

--- a/src/services/CollectionService.ts
+++ b/src/services/CollectionService.ts
@@ -17,6 +17,7 @@ export interface CollectionContextInput {
   tenant: string | undefined;
   collection: string;
   apiKey?: string;
+  userAgent?: string;
 }
 
 export interface NormalizedCollectionContext {
@@ -31,7 +32,8 @@ export function normalizeCollectionContext(
   return normalizeCollectionContextShared(
     input.tenant,
     input.collection,
-    input.apiKey
+    input.apiKey,
+    input.userAgent
   ) as NormalizedCollectionContext;
 }
 

--- a/src/utils/tenant.ts
+++ b/src/utils/tenant.ts
@@ -6,15 +6,35 @@ export function hashApiKey(apiKey: string | undefined): string | undefined {
   return hash.slice(0, 8);
 }
 
+export function hashUserAgent(
+  userAgent: string | undefined
+): string | undefined {
+  if (!userAgent || userAgent.trim() === "") return undefined;
+  const hash = createHash("sha256").update(userAgent).digest("hex");
+  return hash.slice(0, 8);
+}
+
 export function sanitizeCollectionName(
   name: string,
-  apiKeyHash?: string
+  apiKeyHash?: string,
+  userAgentHash?: string
 ): string {
   const cleaned = name.replace(/[^a-zA-Z0-9_]/g, "_").replace(/_+/g, "_");
   const lowered = cleaned.toLowerCase().replace(/^_+/, "");
   const base = lowered.length > 0 ? lowered : "collection";
-  const hasHash = apiKeyHash !== undefined && apiKeyHash.trim().length > 0;
-  return hasHash ? `${base}_${apiKeyHash}` : base;
+
+  const hasApiKey = apiKeyHash !== undefined && apiKeyHash.trim().length > 0;
+  const hasUserAgent =
+    userAgentHash !== undefined && userAgentHash.trim().length > 0;
+
+  if (hasApiKey && hasUserAgent) {
+    return `${base}_${apiKeyHash}_${userAgentHash}`;
+  } else if (hasApiKey) {
+    return `${base}_${apiKeyHash}`;
+  } else if (hasUserAgent) {
+    return `${base}_${userAgentHash}`;
+  }
+  return base;
 }
 
 export function sanitizeTenantId(tenantId: string | undefined): string {

--- a/test/utils/tenant.test.ts
+++ b/test/utils/tenant.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   hashApiKey,
+  hashUserAgent,
   sanitizeCollectionName,
   sanitizeTenantId,
   tableNameFor,
@@ -35,6 +36,33 @@ describe("utils/tenant/hashApiKey", () => {
   });
 });
 
+describe("utils/tenant/hashUserAgent", () => {
+  it("returns undefined when userAgent is undefined", () => {
+    expect(hashUserAgent(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for empty or whitespace-only userAgent", () => {
+    expect(hashUserAgent("")).toBeUndefined();
+    expect(hashUserAgent("   ")).toBeUndefined();
+  });
+
+  it("returns an 8-char hex hash for a non-empty userAgent", () => {
+    const hash = hashUserAgent("Mozilla/5.0 (Windows NT 10.0)");
+    expect(hash).toBeDefined();
+    expect(hash).toHaveLength(8);
+    expect(hash).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it("is deterministic for the same userAgent and differs for different agents", () => {
+    const h1 = hashUserAgent("Chrome/120.0");
+    const h2 = hashUserAgent("Chrome/120.0");
+    const h3 = hashUserAgent("Firefox/121.0");
+
+    expect(h1).toBe(h2);
+    expect(h1).not.toBe(h3);
+  });
+});
+
 describe("utils/tenant/sanitizeCollectionName", () => {
   it("normalizes collection name without hash", () => {
     expect(sanitizeCollectionName("My-Collection")).toBe("my_collection");
@@ -46,8 +74,26 @@ describe("utils/tenant/sanitizeCollectionName", () => {
     );
   });
 
+  it("appends userAgentHash suffix when provided", () => {
+    expect(
+      sanitizeCollectionName("My-Collection", undefined, "e5f6g7h8")
+    ).toBe("my_collection_e5f6g7h8");
+  });
+
+  it("appends both apiKeyHash and userAgentHash when both provided", () => {
+    expect(sanitizeCollectionName("My-Collection", "a1b2c3d4", "e5f6g7h8")).toBe(
+      "my_collection_a1b2c3d4_e5f6g7h8"
+    );
+  });
+
   it("falls back to 'collection' when name is empty", () => {
     expect(sanitizeCollectionName("")).toBe("collection");
+  });
+
+  it("falls back to 'collection' with hashes when name is empty but hashes provided", () => {
+    expect(sanitizeCollectionName("", "a1b2c3d4", "e5f6g7h8")).toBe(
+      "collection_a1b2c3d4_e5f6g7h8"
+    );
   });
 });
 


### PR DESCRIPTION
Closes https://github.com/astandrik/ydb-qdrant/issues/107

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR extends collection name isolation by incorporating the `User-Agent` header into the collection name hash. Previously, collections could be isolated by tenant (`X-Tenant-Id`) and API key (`api-key`), and now `User-Agent` adds another dimension of isolation.

**Key changes:**
- Added `hashUserAgent()` function that creates an 8-character SHA-256 hash of the User-Agent string
- Updated `sanitizeCollectionName()` to accept both `apiKeyHash` and `userAgentHash`, appending them in order: `{name}_{apiKeyHash}_{userAgentHash}`
- Extracted `User-Agent` header in all route handlers (collections and points endpoints) and passed it through the service layer
- Added comprehensive test coverage for the new functionality

**Implementation:**
The User-Agent flows from HTTP headers → route handlers → service layer → shared normalization → hash generation → collection name construction. This allows different clients (with different User-Agents) to maintain isolated collections even when using identical collection names, tenant IDs, and API keys.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The implementation is clean, consistent, well-tested, and follows established patterns in the codebase. The new `hashUserAgent` function mirrors the existing `hashApiKey` implementation. All changes are backward compatible (User-Agent is optional), comprehensive test coverage was added, and the change is isolated to collection name generation without affecting core business logic.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/utils/tenant.ts | 5/5 | Added `hashUserAgent` function mirroring `hashApiKey` logic, updated `sanitizeCollectionName` to append both hashes when provided |
| test/utils/tenant.test.ts | 5/5 | Comprehensive test coverage for `hashUserAgent` and updated `sanitizeCollectionName` tests covering all hash combinations |
| src/services/CollectionService.shared.ts | 5/5 | Updated `normalizeCollectionContextShared` to accept and hash `userAgent` parameter, passing it through to collection name sanitization |
| src/services/CollectionService.ts | 5/5 | Added `userAgent` field to `CollectionContextInput` interface and passed through to shared normalization function |
| src/routes/collections.ts | 5/5 | Extracted `User-Agent` header from requests and passed to all collection service operations |
| src/routes/points.ts | 5/5 | Extracted `User-Agent` header from requests and passed to all points service operations |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Router as collections/points Router
    participant Service as CollectionService
    participant Shared as CollectionService.shared
    participant Utils as tenant.ts
    participant YDB as YDB Database

    Client->>Router: Request with User-Agent header
    Note over Client,Router: Headers: X-Tenant-Id, api-key, User-Agent
    Router->>Service: Call service method with context
    Note over Router,Service: {tenant, collection, apiKey, userAgent}
    Service->>Shared: normalizeCollectionContextShared()
    Shared->>Utils: hashApiKey(apiKey)
    Utils-->>Shared: apiKeyHash (8-char hex)
    Shared->>Utils: hashUserAgent(userAgent)
    Utils-->>Shared: userAgentHash (8-char hex)
    Shared->>Utils: sanitizeCollectionName(name, apiKeyHash, userAgentHash)
    Note over Utils: Appends hashes to collection name
    Note over Utils: Format: {name}_{apiKeyHash}_{userAgentHash}
    Utils-->>Shared: normalizedCollection
    Shared->>Utils: metaKeyFor(tenant, collection)
    Utils-->>Shared: metaKey
    Shared-->>Service: {tenant, collection, metaKey}
    Service->>YDB: Query with normalized collection name
    YDB-->>Service: Result
    Service-->>Router: Response
    Router-->>Client: JSON Response
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->