### PR TITLE
fix: normalize scores

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,11 +126,11 @@ Notes
 
 ## Scoring semantics
 - Returned `score`:
-  - Cosine: **distance** (lower is better; based on `Knn::CosineDistance`).
+  - Cosine: **similarity-like** (higher is better; derived approximately as `1 - Knn::CosineDistance` while preserving ranking).
   - Dot: **similarity** (higher is better; based on `Knn::InnerProductSimilarity`).
   - Euclid/Manhattan: **distance** (lower is better).
 - `score_threshold` behavior:
-  - Cosine: treated as **minimum similarity** in \[0, 1\] (as described by common IDEs/UI); internally converted to a distance cutoff (≈`1 - threshold`) and applied as `score <= cutoff`.
+  - Cosine: treated as **minimum similarity** in \[0, 1\] (as described by common IDEs/UI); applied directly as `score >= threshold`.
   - Dot: treated as **minimum similarity**; applied as `score >= threshold`.
   - Euclid/Manhattan: treated as **maximum distance**; applied as `score <= threshold`.
 

--- a/docs/architecture-and-storage.md
+++ b/docs/architecture-and-storage.md
@@ -48,11 +48,11 @@ Filters are not yet modeled; they can be added if needed.
 ### Scoring Semantics
 
 - Returned `score`:
-  - Cosine: **distance** (lower is better; `Knn::CosineDistance`).
+  - Cosine: **similarity-like** (higher is better; derived approximately as `1 - Knn::CosineDistance` while preserving ranking).
   - Dot: **similarity** (higher is better; `Knn::InnerProductSimilarity`).
   - Euclid/Manhattan: **distance** (lower is better).
 - `score_threshold` behavior:
-  - Cosine: treated as **minimum similarity** in \[0, 1\] (UI/IDE-friendly); internally mapped to a distance cutoff (≈`1 - threshold`) and applied as `score <= cutoff`.
+  - Cosine: treated as **minimum similarity** in \[0, 1\] (UI/IDE-friendly) and applied directly as `score >= threshold`.
   - Dot: treated as **minimum similarity**; applied as `score >= threshold`.
   - Euclid/Manhattan: treated as **maximum distance**; applied as `score <= threshold`.
 

--- a/test/services/QdrantService.test.ts
+++ b/test/services/QdrantService.test.ts
@@ -363,14 +363,13 @@ describe("QdrantService (with mocked YDB)", () => {
     expect(result.points.map((p) => p.id)).toEqual(["p1"]);
   });
 
-  it("interprets score_threshold for Cosine as minimum similarity while using distance scores", async () => {
+  it("interprets score_threshold for Cosine as minimum similarity and returns similarity-like scores", async () => {
     vi.mocked(collectionsRepo.getCollectionMeta).mockResolvedValueOnce({
       table: "qdr_tenant_a__my_collection",
       dimension: 4,
       distance: "Cosine",
       vectorType: "float",
     });
-    // Internal scores are distances; 0.1 is closer (more similar) than 0.7.
     vi.mocked(pointsRepo.searchPoints).mockResolvedValueOnce([
       { id: "p1", score: 0.1 },
       { id: "p2", score: 0.7 },
@@ -382,12 +381,13 @@ describe("QdrantService (with mocked YDB)", () => {
         vector: [0, 0, 0, 1],
         top: 10,
         with_payload: false,
-        // IDE provides similarity threshold; 0.5 → allow distances up to ~0.5.
         score_threshold: 0.5,
       }
     );
 
     expect(result.points.map((p) => p.id)).toEqual(["p1"]);
+    // Repository returns distance scores; service converts to ~1 - distance.
+    expect(result.points[0]?.score).toBeCloseTo(0.9, 5);
   });
 
   it("maps vector dimension mismatch during search to QdrantServiceError 400", async () => {


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR normalizes Cosine distance scores to similarity-like scores in the service layer, improving API consistency with IDE/UI expectations.

- Transforms Cosine scores from distance (lower is better, range [0,2]) to similarity-like (higher is better, `1 - distance`)
- Simplifies threshold filtering by treating Cosine the same as Dot (`score >= threshold`)
- Preserves ranking order (monotonic transformation)
- Updates documentation to reflect the new scoring semantics

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it's a well-tested improvement to API consistency with no breaking changes to behavior.
- The transformation is mathematically correct and rank-preserving. The test verifies the expected behavior. Documentation is properly updated. No logical issues found.
- No files require special attention.

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/services/PointsService.ts | 5/5 | Normalizes Cosine distance scores to similarity-like scores (1 - distance) before filtering and returning results. Logic is correct and rank-preserving. |
| test/services/QdrantService.test.ts | 5/5 | Updated test to verify new Cosine score normalization behavior. Correctly expects transformed score (0.9 from distance 0.1). |
| AGENTS.md | 5/5 | Documentation updated to reflect that Cosine scores are now similarity-like (higher is better) instead of distance. |
| docs/architecture-and-storage.md | 5/5 | Architecture documentation updated to match new Cosine scoring semantics. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant PointsService
    participant Repository
    participant YDB

    Client->>PointsService: searchPoints(vector, threshold)
    PointsService->>Repository: searchPoints(...)
    Repository->>YDB: SELECT ... Knn::CosineDistance(...)
    YDB-->>Repository: hits with distance scores
    Repository-->>PointsService: hits [{id, score: distance}]
    Note over PointsService: Transform: score = 1 - distance
    Note over PointsService: Filter: score >= threshold
    PointsService-->>Client: points [{id, score: similarity}]
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

### Load test (soak, multi_table)

| Metric | Value |
|--------|-------|
| Operations/sec | 52.15 |
| Search p95 | 124 ms |
| Search p99 | 0 ms |
| Error rate | 0.0000 % |

### Load test (soak, one_table)

| Metric | Value |
|--------|-------|
| Operations/sec | 52.57 |
| Search p95 | 116 ms |
| Search p99 | 0 ms |
| Error rate | 0.0000 % |

### Load test (stress, multi_table)

| Metric | Value |
|--------|-------|
| Max VUs reached | 350 |
| Average RPS | 106.64 |
| Search p95 | 4027 ms |
| Search p99 | 0 ms |
| Error rate | 0.0000 % |

#### Breaking point

Breaking point detected at **350 VUs** (~106.64 RPS).

### Load test (stress, one_table)

| Metric | Value |
|--------|-------|
| Max VUs reached | 600 |
| Average RPS | 134.73 |
| Search p95 | 5943 ms |
| Search p99 | 0 ms |
| Error rate | 0.0000 % |

#### Breaking point

Breaking point detected at **600 VUs** (~134.73 RPS).