### PR TITLE
fix: add transient checks, idempotent and cached flags

### DIFF
--- a/src/repositories/collectionsRepo.multi-table.ts
+++ b/src/repositories/collectionsRepo.multi-table.ts
@@ -4,6 +4,7 @@ import {
   withSession,
   TableDescription,
   Column,
+  createExecuteQuerySettings,
 } from "../ydb/client.js";
 import type { DistanceKind, VectorType } from "../types";
 import { upsertCollectionMeta } from "./collectionsRepo.shared.js";
@@ -41,6 +42,12 @@ export async function deleteCollectionMultiTable(
     DELETE FROM qdr__collections WHERE collection = $collection;
   `;
   await withSession(async (s) => {
-    await s.executeQuery(delMeta, { $collection: TypedValues.utf8(metaKey) });
+    const settings = createExecuteQuerySettings();
+    await s.executeQuery(
+      delMeta,
+      { $collection: TypedValues.utf8(metaKey) },
+      undefined,
+      settings
+    );
   });
 }

--- a/src/repositories/collectionsRepo.ts
+++ b/src/repositories/collectionsRepo.ts
@@ -1,4 +1,8 @@
-import { TypedValues, withSession } from "../ydb/client.js";
+import {
+  TypedValues,
+  withSession,
+  createExecuteQuerySettings,
+} from "../ydb/client.js";
 import type { DistanceKind, VectorType } from "../types";
 import { mapDistanceToIndexParam } from "../utils/distance.js";
 import {
@@ -51,9 +55,15 @@ export async function getCollectionMeta(metaKey: string): Promise<{
     WHERE collection = $collection;
   `;
   const res = await withSession(async (s) => {
-    return await s.executeQuery(qry, {
-      $collection: TypedValues.utf8(metaKey),
-    });
+    const settings = createExecuteQuerySettings();
+    return await s.executeQuery(
+      qry,
+      {
+        $collection: TypedValues.utf8(metaKey),
+      },
+      undefined,
+      settings
+    );
   });
   const rowset = res.resultSets?.[0];
   if (!rowset || rowset.rows?.length !== 1) return null;

--- a/src/ydb/client.ts
+++ b/src/ydb/client.ts
@@ -1,4 +1,8 @@
-import type { Session, IAuthService } from "ydb-sdk";
+import type {
+  Session,
+  IAuthService,
+  ExecuteQuerySettings as YdbExecuteQuerySettings,
+} from "ydb-sdk";
 import { createRequire } from "module";
 import {
   YDB_DATABASE,
@@ -17,9 +21,25 @@ const {
   TypedValues,
   TableDescription,
   Column,
+  ExecuteQuerySettings,
 } = require("ydb-sdk") as typeof import("ydb-sdk");
 
-export { Types, TypedValues, TableDescription, Column };
+export { Types, TypedValues, TableDescription, Column, ExecuteQuerySettings };
+
+export function createExecuteQuerySettings(options?: {
+  keepInCache?: boolean;
+  idempotent?: boolean;
+}): YdbExecuteQuerySettings {
+  const { keepInCache = true, idempotent = true } = options ?? {};
+  const settings = new ExecuteQuerySettings();
+  if (keepInCache) {
+    settings.withKeepInCache(true);
+  }
+  if (idempotent) {
+    settings.withIdempotent(true);
+  }
+  return settings;
+}
 
 const DRIVER_READY_TIMEOUT_MS = 15000;
 const TABLE_SESSION_TIMEOUT_MS = 20000;

--- a/test/repositories/PointsRepo.client-side-serialization.test.ts
+++ b/test/repositories/PointsRepo.client-side-serialization.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
 
 vi.mock("../../src/ydb/client.js", () => {
+  const createExecuteQuerySettings = vi.fn(() => ({
+    kind: "ExecuteQuerySettings",
+  }));
+
   return {
     Types: {
       UTF8: "UTF8",
@@ -16,6 +20,7 @@ vi.mock("../../src/ydb/client.js", () => {
       bytes: vi.fn((v: unknown) => ({ type: "bytes", v })),
     },
     withSession: vi.fn(),
+    createExecuteQuerySettings,
   };
 });
 

--- a/test/repositories/collectionsRepo.test.ts
+++ b/test/repositories/collectionsRepo.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
 
 vi.mock("../../src/ydb/client.js", () => {
+  const createExecuteQuerySettings = vi.fn(() => ({
+    kind: "ExecuteQuerySettings",
+  }));
+
   return {
     Types: {
       UTF8: "UTF8",
@@ -40,6 +44,7 @@ vi.mock("../../src/ydb/client.js", () => {
         this.type = type;
       }
     },
+    createExecuteQuerySettings,
   };
 });
 

--- a/test/repositories/pointsRepo.index-disabled.test.ts
+++ b/test/repositories/pointsRepo.index-disabled.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
 
 vi.mock("../../src/ydb/client.js", () => {
+  const createExecuteQuerySettings = vi.fn(() => ({
+    kind: "ExecuteQuerySettings",
+  }));
+
   return {
     Types: {
       UTF8: "UTF8",
@@ -15,6 +19,7 @@ vi.mock("../../src/ydb/client.js", () => {
       list: vi.fn((t: unknown, list: unknown[]) => ({ type: "list", t, list })),
     },
     withSession: vi.fn(),
+    createExecuteQuerySettings,
   };
 });
 

--- a/test/repositories/pointsRepo.test.ts
+++ b/test/repositories/pointsRepo.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
 
 vi.mock("../../src/ydb/client.js", () => {
+  const createExecuteQuerySettings = vi.fn(() => ({
+    kind: "ExecuteQuerySettings",
+  }));
+
   return {
     Types: {
       UTF8: "UTF8",
@@ -20,6 +24,7 @@ vi.mock("../../src/ydb/client.js", () => {
       list: vi.fn((t: unknown, list: unknown[]) => ({ type: "list", t, list })),
     },
     withSession: vi.fn(),
+    createExecuteQuerySettings,
   };
 });
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR enhances YDB query resilience by adding comprehensive transient error detection, standardized query settings with idempotent and cache flags, and retry wrappers for critical operations.

**Key changes:**
- Expanded `isTransientYdbError` to detect additional transient conditions (`overloaded`, `is in process of split`, `wrong shard state`, `Rejecting data TxId`) and inspect the `issues` field on error objects
- Created `createExecuteQuerySettings` helper that enables `keepInCache` and `idempotent` flags by default for all queries
- Applied query settings consistently across all `executeQuery` calls in repositories (collections and points, both one-table and multi-table modes)
- Wrapped `deleteCollectionOneTable` operation in `withRetry` to handle transient errors during large collection deletions
- Updated all test mocks to include the new `createExecuteQuerySettings` function

The changes follow a systematic pattern: every `executeQuery` call now receives settings as the 4th parameter, and critical batch operations are protected by retry logic with exponential backoff.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are well-structured and consistent across the codebase. The additions improve reliability without altering core logic, use established patterns (retry with exponential backoff), and include proper test coverage updates. All modifications follow the same safe pattern of adding settings to existing queries.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/utils/retry.ts | 5/5 | Enhanced transient error detection to include more YDB-specific transient errors (overloaded, split operations, wrong shard state) with proper issues field inspection |
| src/ydb/client.ts | 5/5 | Added `createExecuteQuerySettings` helper to standardize query settings with `keepInCache` and `idempotent` flags enabled by default |
| src/repositories/collectionsRepo.one-table.ts | 5/5 | Applied query settings to all executeQuery calls and wrapped deleteCollectionOneTable in withRetry for transient error handling |
| src/repositories/pointsRepo.multi-table.ts | 5/5 | Applied query settings consistently across upsert, search, and delete operations |
| src/repositories/pointsRepo.one-table.ts | 5/5 | Applied query settings to all executeQuery calls in upsert, search (exact and approximate), and delete operations |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Client Code
    participant Repo as Repository Layer
    participant Retry as withRetry
    participant Session as YDB Session
    participant YDB as YDB Database

    Client->>Repo: upsertPoints/searchPoints/deleteCollection
    Repo->>Repo: createExecuteQuerySettings()
    Note over Repo: Sets idempotent=true<br/>keepInCache=true
    
    alt Operation with retry wrapper
        Repo->>Retry: withRetry(fn, options)
        loop Max 6 retries
            Retry->>Session: withSession(executeQuery)
            Session->>YDB: Execute query with settings
            alt Success
                YDB-->>Session: Result
                Session-->>Retry: Success
                Retry-->>Repo: Success
            else Transient Error
                YDB-->>Session: Error (overloaded/split/schema mismatch)
                Session-->>Retry: Error
                Retry->>Retry: isTransientYdbError(error)
                Note over Retry: Checks error message<br/>and issues field
                Retry->>Retry: Exponential backoff
                Note over Retry: Wait with jitter
            else Non-transient Error
                YDB-->>Session: Error
                Session-->>Retry: Error
                Retry-->>Repo: Throw error
            end
        end
    else Direct operation
        Repo->>Session: withSession(executeQuery)
        Session->>YDB: Execute query with settings
        YDB-->>Session: Result
        Session-->>Repo: Result
    end
    
    Repo-->>Client: Return result
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

### Load test (soak, one_table)

| Metric | Value |
|--------|-------|
| Operations/sec | 64.29 |
| Search p95 | 95 ms |
| Search p99 | 0 ms |
| Error rate | 0.0000 % |
### Load test (soak, multi_table)

| Metric | Value |
|--------|-------|
| Operations/sec | 61.21 |
| Search p95 | 104 ms |
| Search p99 | 0 ms |
| Error rate | 0.0000 % |

### Load test (stress, one_table)

| Metric | Value |
|--------|-------|
| Max VUs reached | 600 |
| Average RPS | 149.17 |
| Search p95 | 5799 ms |
| Search p99 | 0 ms |
| Error rate | 0.0000 % |

#### Breaking point

Breaking point detected at **600 VUs** (~149.17 RPS).

### Load test (stress, multi_table)

| Metric | Value |
|--------|-------|
| Max VUs reached | 600 |
| Average RPS | 141.33 |
| Search p95 | 5409 ms |
| Search p99 | 0 ms |
| Error rate | 0.0000 % |

#### Breaking point

Breaking point detected at **600 VUs** (~141.33 RPS).