### PR TITLE
fix: search

### DIFF
--- a/src/routes/points.ts
+++ b/src/routes/points.ts
@@ -144,7 +144,11 @@ pointsRouter.post(
         },
         req.body
       );
-      res.json({ status: "ok", result: points.map(toQdrantScoredPoint) });
+      // Qdrant-compatible: /points/query returns QueryResponse with { points: ScoredPoint[] }.
+      res.json({
+        status: "ok",
+        result: { points: points.map(toQdrantScoredPoint) },
+      });
     } catch (err: unknown) {
       if (err instanceof QdrantServiceError) {
         return res.status(err.statusCode).json(err.payload);

--- a/test/routes/points.test.ts
+++ b/test/routes/points.test.ts
@@ -195,17 +195,19 @@ describe("pointsRouter (HTTP, mocked service)", () => {
     );
     expect(queryRes.statusCode).toBe(200);
     expect(queryRes.body).toMatchObject({ status: "ok" });
-    expect(queryRes.body?.result).toEqual([
-      expect.objectContaining({
-        id: "p2",
-        score: 0.8,
-        version: 0,
-        payload: null,
-        vector: null,
-        shard_key: null,
-        order_value: null,
-      }),
-    ]);
+    expect(queryRes.body?.result).toEqual({
+      points: [
+        expect.objectContaining({
+          id: "p2",
+          score: 0.8,
+          version: 0,
+          payload: null,
+          vector: null,
+          shard_key: null,
+          order_value: null,
+        }),
+      ],
+    });
 
     const deleteBody = { points: ["p1", "p2"] };
     const deleteReq = createRequest({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures Qdrant API compatibility for query endpoint.
> 
> - Updates `POST /collections/:collection/points/query` to return `result: { points: ScoredPoint[] }` instead of a bare array
> - Adds inline comment documenting Qdrant-compatible shape
> - Adjusts tests in `points.test.ts` to expect the new `result` structure
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15ee8fe7eebbffc3ee3fe769fbcc64137d5536fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed the `/collections/:collection/points/query` endpoint response format to match Qdrant's API specification. The endpoint now returns `{ status: "ok", result: { points: [...] } }` instead of `{ status: "ok", result: [...] }`, wrapping the points array in an object.

**Key changes:**
- Updated `src/routes/points.ts:147-151` to wrap the mapped points array in a `{ points: [...] }` object
- Added comment explaining the Qdrant-compatible QueryResponse format
- Updated corresponding test in `test/routes/points.test.ts:198-210` to expect the nested structure

This change aligns the query endpoint with Qdrant's QueryResponse type, which differs from the SearchResponse format used by the `/points/search` endpoint (which returns the array directly). The fix ensures compatibility with Qdrant clients expecting the proper response structure.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a simple, well-tested API response format fix that aligns with Qdrant's specification. The modification is minimal (wrapping an array in an object), has corresponding test updates that validate the new behavior, and doesn't affect any business logic or introduce security concerns. The comment added explains the reasoning clearly.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/routes/points.ts | Changed `/points/query` response format to match Qdrant API spec by wrapping points array in `{ points: [...] }` object, making it consistent with Qdrant's QueryResponse type |
| test/routes/points.test.ts | Updated test expectations to match new query response format with nested `points` array |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant pointsRouter
    participant queryPoints
    participant executeSearch
    participant repoSearchPoints
    participant YDB
    
    Client->>pointsRouter: POST /collections/:collection/points/query
    pointsRouter->>queryPoints: queryPoints(ctx, body)
    queryPoints->>queryPoints: normalizeSearchBodyForQuery(body)
    queryPoints->>executeSearch: executeSearch(ctx, normalizedSearch, "query")
    executeSearch->>repoSearchPoints: repoSearchPoints(tableName, vector, top, ...)
    repoSearchPoints->>YDB: Execute search query
    YDB-->>repoSearchPoints: Return hits
    repoSearchPoints-->>executeSearch: Return points
    executeSearch-->>queryPoints: { points: [...] }
    queryPoints-->>pointsRouter: { points: [...] }
    Note over pointsRouter: Wraps result in<br/>{ points: [...] }
    pointsRouter->>pointsRouter: res.json({ status: "ok", result: { points: [...] } })
    pointsRouter-->>Client: { status: "ok", result: { points: [...] } }
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

### Load test (soak, one_table)

| Metric | Value |
|--------|-------|
| Operations/sec | 72.46 |
| Search p95 | 40 ms |
| Search p99 | 0 ms |
| Error rate | 0.0000 % |

### Load test (stress, one_table)

| Metric | Value |
|--------|-------|
| Max VUs reached | 600 |
| Average RPS | 179.70 |
| Search p95 | 4089 ms |
| Search p99 | 0 ms |
| Error rate | 0.0137 % |

#### Breaking point

Breaking point detected at **600 VUs** (~179.70 RPS).