### PR TITLE
fix: npm release

### DIFF
--- a/.github/workflows/publish-ydb-qdrant.yml
+++ b/.github/workflows/publish-ydb-qdrant.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout (release)
@@ -26,8 +29,11 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "22.14.0"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Update npm
+        run: npm install -g npm@^11.5.1
 
       - name: Install dependencies
         run: npm ci
@@ -43,7 +49,4 @@ jobs:
 
       - name: Publish to npm
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the npm publish workflow by pinning the Node.js version to `22.14.0`, adding a step to upgrade npm to `^11.5.1`, and adding `id-token: write` permissions — likely intended to support npm provenance publishing. However, it also removes the `NODE_AUTH_TOKEN` env var from the `npm publish` step without configuring a provenance-based alternative, which will cause every publish attempt to fail with a 401 from the registry.

<h3>Confidence Score: 2/5</h3>

Not safe to merge — the npm publish step will fail with 401 due to missing registry authentication.

There is a clear P1 defect: removing the registry auth token env var without a provenance-based replacement breaks every publish triggered by this workflow. The version-pinning and npm upgrade changes are positive, but the broken auth is a blocker.

.github/workflows/publish-ydb-qdrant.yml — specifically the publish step where the auth env var was removed.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/publish-ydb-qdrant.yml | Adds job-level OIDC permissions and pins Node/npm versions, but removes NODE_AUTH_TOKEN from the publish step without configuring a provenance-based alternative — this will cause npm publish to fail with 401. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant SN as setup-node@v4
    participant NPM as npm CLI
    participant REG as npmjs.org registry

    GHA->>SN: setup Node 22.14.0 + registry-url
    SN->>GHA: writes ~/.npmrc with auth token placeholder
    GHA->>NPM: npm install -g npm (upgrade)
    GHA->>NPM: npm ci / lint / test / build
    GHA->>NPM: npm publish (auth token missing)
    NPM->>REG: publish request (empty auth)
    REG-->>NPM: 401 Unauthorized
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/publish-ydb-qdrant.yml`, line 44-51 ([link](https://github.com/astandrik/ydb-qdrant/blob/0d20ed28cae4345cbc14b2cf463936aa18799607/.github/workflows/publish-ydb-qdrant.yml#L44-L51)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`prepublishOnly` causes duplicate test + build runs**

   `package.json` defines `"prepublishOnly": "npm test && npm run build"`, which means every `npm publish` invocation also runs tests and a full build. The workflow already runs explicit **Lint**, **Run tests**, and **Build** steps before publishing, so these run twice. Consider either removing `prepublishOnly` from `package.json` for CI or passing `--ignore-scripts` to the publish command to avoid redundant work.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/publish-ydb-qdrant.yml
   Line: 44-51

   Comment:
   **`prepublishOnly` causes duplicate test + build runs**

   `package.json` defines `"prepublishOnly": "npm test && npm run build"`, which means every `npm publish` invocation also runs tests and a full build. The workflow already runs explicit **Lint**, **Run tests**, and **Build** steps before publishing, so these run twice. Consider either removing `prepublishOnly` from `package.json` for CI or passing `--ignore-scripts` to the publish command to avoid redundant work.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/publish-ydb-qdrant.yml
Line: 36

Comment:
**Non-deterministic npm version in CI**

Using `npm@^11.5.1` allows any `11.x` release above `11.5.1` to be installed, so the resolved version can silently change between runs. Pin to an exact version (e.g. `npm@11.5.1`) for reproducible CI behaviour.

```suggestion
        run: npm install -g npm@11.5.1
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/publish-ydb-qdrant.yml
Line: 44-51

Comment:
**`prepublishOnly` causes duplicate test + build runs**

`package.json` defines `"prepublishOnly": "npm test && npm run build"`, which means every `npm publish` invocation also runs tests and a full build. The workflow already runs explicit **Lint**, **Run tests**, and **Build** steps before publishing, so these run twice. Consider either removing `prepublishOnly` from `package.json` for CI or passing `--ignore-scripts` to the publish command to avoid redundant work.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/publish-ydb-qdrant.yml
Line: 50-51

Comment:
**Missing npm authentication — publish will fail with 401**

`actions/setup-node@v4` writes an auth token placeholder into `~/.npmrc` that resolves from the `NODE_AUTH_TOKEN` environment variable at runtime. That env var was removed from the publish step in this PR, so the placeholder expands to an empty string and the registry rejects the publish request.

The `id-token: write` permission supports OIDC-based provenance attestation, but it does not automatically substitute for a registry auth token unless `--provenance` is passed to `npm publish` and the package is configured for trusted publishing on npmjs.com. Neither condition is met here.

Restore the env block on the publish step (pointing to the same registry secret used before) or, if the intent is to switch to OIDC provenance publishing, add `--provenance` to the publish command and configure the package on npmjs.com accordingly.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: npm release"](https://github.com/astandrik/ydb-qdrant/commit/0d20ed28cae4345cbc14b2cf463936aa18799607) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29130357)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->

### Load test (soak, one_table_exact)

| Metric | Value |
|--------|-------|
| Operations/sec | 66.61 |
| Search p95 | 74 ms |
| Search p99 | 0 ms |
| Error rate | 0.0000 % |

### Load test (stress, one_table_exact)

| Metric | Value |
|--------|-------|
| Max VUs reached | 600 |
| Average RPS | 155.72 |
| Search p95 | 4775.75 ms |
| Search p99 | 0 ms |
| Error rate | 0.0470 % |

#### Breaking point

Breaking point detected at **600 VUs** (~155.72 RPS).