### PR TITLE
Add structured JSON API errors

### DIFF
--- a/src/middleware/upsertRequestTimeout.ts
+++ b/src/middleware/upsertRequestTimeout.ts
@@ -3,6 +3,7 @@ import {
     UPSERT_BODY_TIMEOUT_MS,
     UPSERT_HTTP_TIMEOUT_MS,
 } from "../config/env.js";
+import { sendJsonError } from "../utils/jsonErrorResponse.js";
 
 const UPSERT_REQUEST_TIMEOUT_STATE = Symbol("upsertRequestTimeoutState");
 const RETRY_AFTER_SECONDS = "1";
@@ -142,8 +143,9 @@ export function respondUpsertRequestTimedOut(args: {
     markUpsertRequestTimedOut(args.req, args.timeoutMs, args.timeoutPhase);
     args.res.setHeader("Retry-After", RETRY_AFTER_SECONDS);
     args.res.setHeader("Connection", "close");
-    args.res.status(503).json({
-        status: "error",
+    sendJsonError(args.res, {
+        statusCode: 503,
+        code: "REQUEST_TIMEOUT",
         error: TIMEOUT_ERROR_MESSAGE,
     });
     args.res.once("finish", () => {

--- a/src/routes/collections.ts
+++ b/src/routes/collections.ts
@@ -8,6 +8,7 @@ import {
 import { QdrantServiceError } from "../services/errors.js";
 import { logger } from "../logging/logger.js";
 import { qdrantResponse } from "../utils/qdrantResponse.js";
+import { sendJsonError } from "../utils/jsonErrorResponse.js";
 import {
     isAnonymousIdentityError,
     resolveRequestNamespaceUserUid,
@@ -33,11 +34,18 @@ function buildCollectionContext(req: Request): {
 
 function sendKnownRouteError(res: Response, err: unknown): boolean {
     if (err instanceof QdrantServiceError) {
-        res.status(err.statusCode).json(err.payload);
+        sendJsonError(res, {
+            statusCode: err.statusCode,
+            error: err.payload.error,
+        });
         return true;
     }
     if (isAnonymousIdentityError(err)) {
-        res.status(400).json({ status: "error", error: err.message });
+        sendJsonError(res, {
+            statusCode: 400,
+            code: "AUTHENTICATION_REQUIRED",
+            error: err.message,
+        });
         return true;
     }
     return false;
@@ -58,7 +66,7 @@ collectionsRouter.put(
             logger.error({ err }, "build index failed");
             const errorMessage =
                 err instanceof Error ? err.message : String(err);
-            res.status(500).json({ status: "error", error: errorMessage });
+            sendJsonError(res, { statusCode: 500, error: errorMessage });
         }
     }
 );
@@ -78,7 +86,7 @@ collectionsRouter.put(
             logger.error({ err }, "create collection failed");
             const errorMessage =
                 err instanceof Error ? err.message : String(err);
-            res.status(500).json({ status: "error", error: errorMessage });
+            sendJsonError(res, { statusCode: 500, error: errorMessage });
         }
     }
 );
@@ -97,7 +105,7 @@ collectionsRouter.get(
             logger.error({ err }, "get collection failed");
             const errorMessage =
                 err instanceof Error ? err.message : String(err);
-            res.status(500).json({ status: "error", error: errorMessage });
+            sendJsonError(res, { statusCode: 500, error: errorMessage });
         }
     }
 );
@@ -117,7 +125,7 @@ collectionsRouter.delete(
             logger.error({ err }, "delete collection failed");
             const errorMessage =
                 err instanceof Error ? err.message : String(err);
-            res.status(500).json({ status: "error", error: errorMessage });
+            sendJsonError(res, { statusCode: 500, error: errorMessage });
         }
     }
 );

--- a/src/routes/points.ts
+++ b/src/routes/points.ts
@@ -26,6 +26,7 @@ import {
     resolveRequestNamespaceUserUid,
     resolveRequestSigningKey,
 } from "../utils/requestIdentity.js";
+import { sendJsonError } from "../utils/jsonErrorResponse.js";
 
 export const pointsRouter = Router();
 
@@ -50,11 +51,18 @@ function shouldSkipResponse(req: Request, res: Response): boolean {
 
 function sendKnownRouteError(res: Response, err: unknown): boolean {
     if (err instanceof QdrantServiceError) {
-        res.status(err.statusCode).json(err.payload);
+        sendJsonError(res, {
+            statusCode: err.statusCode,
+            error: err.payload.error,
+        });
         return true;
     }
     if (isAnonymousIdentityError(err)) {
-        res.status(400).json({ status: "error", error: err.message });
+        sendJsonError(res, {
+            statusCode: 400,
+            code: "AUTHENTICATION_REQUIRED",
+            error: err.message,
+        });
         return true;
     }
     return false;
@@ -134,7 +142,7 @@ pointsRouter.post(
             logger.error({ err }, "retrieve points failed");
             const errorMessage =
                 err instanceof Error ? err.message : String(err);
-            res.status(500).json({ status: "error", error: errorMessage });
+            sendJsonError(res, { statusCode: 500, error: errorMessage });
         }
     }
 );
@@ -170,7 +178,7 @@ pointsRouter.put(
                 if (shouldSkipResponse(req, res)) {
                     return;
                 }
-                res.status(500).json({ status: "error", error: errorMessage });
+                sendJsonError(res, { statusCode: 500, error: errorMessage });
                 return;
             }
             if (shouldSkipResponse(req, res)) {
@@ -180,7 +188,7 @@ pointsRouter.put(
                 return;
             }
             logger.error({ err }, "upsert points (PUT) failed");
-            res.status(500).json({ status: "error", error: errorMessage });
+            sendJsonError(res, { statusCode: 500, error: errorMessage });
         }
     }
 );
@@ -215,7 +223,7 @@ pointsRouter.post(
                 if (shouldSkipResponse(req, res)) {
                     return;
                 }
-                res.status(500).json({ status: "error", error: errorMessage });
+                sendJsonError(res, { statusCode: 500, error: errorMessage });
                 return;
             }
             if (shouldSkipResponse(req, res)) {
@@ -225,7 +233,7 @@ pointsRouter.post(
                 return;
             }
             logger.error({ err }, "upsert points failed");
-            res.status(500).json({ status: "error", error: errorMessage });
+            sendJsonError(res, { statusCode: 500, error: errorMessage });
         }
     }
 );
@@ -248,12 +256,12 @@ pointsRouter.post(
                     { err },
                     "YDB compilation timeout during search points; scheduling process exit"
                 );
-                res.status(500).json({ status: "error", error: errorMessage });
+                sendJsonError(res, { statusCode: 500, error: errorMessage });
                 scheduleExit(1);
                 return;
             }
             logger.error({ err }, "search points failed");
-            res.status(500).json({ status: "error", error: errorMessage });
+            sendJsonError(res, { statusCode: 500, error: errorMessage });
         }
     }
 );
@@ -278,12 +286,12 @@ pointsRouter.post(
                     { err },
                     "YDB compilation timeout during search points (query); scheduling process exit"
                 );
-                res.status(500).json({ status: "error", error: errorMessage });
+                sendJsonError(res, { statusCode: 500, error: errorMessage });
                 scheduleExit(1);
                 return;
             }
             logger.error({ err }, "search points (query) failed");
-            res.status(500).json({ status: "error", error: errorMessage });
+            sendJsonError(res, { statusCode: 500, error: errorMessage });
         }
     }
 );
@@ -303,7 +311,7 @@ pointsRouter.post(
             logger.error({ err }, "delete points failed");
             const errorMessage =
                 err instanceof Error ? err.message : String(err);
-            res.status(500).json({ status: "error", error: errorMessage });
+            sendJsonError(res, { statusCode: 500, error: errorMessage });
         }
     }
 );

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import { isYdbAvailable, isCompilationTimeoutError } from "./ydb/client.js";
 import { verifyCollectionsQueryCompilationForStartup } from "./repositories/collectionsRepo.js";
 import { logger } from "./logging/logger.js";
 import { scheduleExit } from "./utils/exit.js";
+import { sendJsonError } from "./utils/jsonErrorResponse.js";
 
 export async function healthHandler(
     _req: Request,
@@ -26,7 +27,11 @@ export async function healthHandler(
     const ok = await isYdbAvailable();
     if (!ok) {
         logger.error("YDB unavailable during health check");
-        res.status(503).json({ status: "error", error: "YDB unavailable" });
+        sendJsonError(res, {
+            statusCode: 503,
+            code: "HEALTH_CHECK_FAILED",
+            error: "YDB unavailable",
+        });
         scheduleExit(1);
         return;
     }
@@ -41,8 +46,9 @@ export async function healthHandler(
                 ? "YDB compilation timeout during health probe"
                 : "YDB health probe failed"
         );
-        res.status(503).json({
-            status: "error",
+        sendJsonError(res, {
+            statusCode: 503,
+            code: "HEALTH_CHECK_FAILED",
             error: "YDB health probe failed",
         });
         scheduleExit(1);
@@ -93,9 +99,21 @@ export function buildServer() {
             if (res.headersSent || res.writableEnded) {
                 return;
             }
-            res.status(400).json({ status: "error", error: "request aborted" });
+            sendJsonError(res, {
+                statusCode: 400,
+                code: "REQUEST_ABORTED",
+                error: "request aborted",
+            });
         }
     );
+
+    app.use((_req: Request, res: Response): void => {
+        sendJsonError(res, {
+            statusCode: 404,
+            code: "NOT_FOUND",
+            error: "route not found",
+        });
+    });
 
     // Catch-all error handler: avoid Express default handler printing stacktraces to stderr
     // and provide consistent JSON error responses.
@@ -121,8 +139,13 @@ export function buildServer() {
             const statusCode = extractHttpStatusCode(err) ?? 500;
             const errorMessage =
                 err instanceof Error ? err.message : String(err);
-            res.status(statusCode).json({
-                status: "error",
+            sendJsonError(res, {
+                statusCode,
+                code: isBodyParserRequestReadError(err)
+                    ? statusCode === 413
+                        ? "PAYLOAD_TOO_LARGE"
+                        : "VALIDATION_ERROR"
+                    : undefined,
                 error: errorMessage,
             });
         }

--- a/src/utils/jsonErrorResponse.ts
+++ b/src/utils/jsonErrorResponse.ts
@@ -18,6 +18,7 @@ export type JsonErrorResponse = {
     status: "error";
     error: string;
     code: JsonErrorCode;
+    details?: unknown;
     message: string;
     resolution: string;
     request_id: string;
@@ -25,12 +26,24 @@ export type JsonErrorResponse = {
 
 type JsonErrorInput = {
     code?: JsonErrorCode;
+    details?: unknown;
     error: unknown;
     message?: string;
     requestId?: string;
     resolution?: string;
     statusCode: number;
 };
+
+function isFlattenedValidationError(
+    error: unknown
+): error is Record<string, unknown> {
+    return (
+        !!error &&
+        typeof error === "object" &&
+        ("fieldErrors" in error || "formErrors" in error) &&
+        Object.keys(error).length <= 2
+    );
+}
 
 function stringifyError(error: unknown): string {
     if (typeof error === "string") {
@@ -40,10 +53,7 @@ function stringifyError(error: unknown): string {
         return error.message;
     }
     if (error && typeof error === "object") {
-        if (
-            ("fieldErrors" in error || "formErrors" in error) &&
-            Object.keys(error).length <= 2
-        ) {
+        if (isFlattenedValidationError(error)) {
             return "validation failed";
         }
         try {
@@ -53,6 +63,10 @@ function stringifyError(error: unknown): string {
         }
     }
     return String(error);
+}
+
+function getErrorDetails(error: unknown): Record<string, unknown> | undefined {
+    return isFlattenedValidationError(error) ? error : undefined;
 }
 
 function inferErrorCode(args: {
@@ -156,8 +170,9 @@ export function createJsonErrorResponse(
             message,
             statusCode: args.statusCode,
         });
+    const details = args.details ?? getErrorDetails(args.error);
 
-    return {
+    const response: JsonErrorResponse = {
         status: "error",
         error: message,
         code,
@@ -165,6 +180,10 @@ export function createJsonErrorResponse(
         resolution: args.resolution ?? defaultResolution(code),
         request_id: args.requestId ?? getRequestId(res),
     };
+    if (details !== undefined) {
+        response.details = details;
+    }
+    return response;
 }
 
 export function sendJsonError(res: Response, args: JsonErrorInput): void {

--- a/src/utils/jsonErrorResponse.ts
+++ b/src/utils/jsonErrorResponse.ts
@@ -1,0 +1,172 @@
+import type { Response } from "express";
+import { getRequestContext } from "../logging/requestContext.js";
+
+export type JsonErrorCode =
+    | "AUTHENTICATION_REQUIRED"
+    | "BAD_REQUEST"
+    | "COLLECTION_NOT_FOUND"
+    | "HEALTH_CHECK_FAILED"
+    | "INTERNAL_ERROR"
+    | "NOT_FOUND"
+    | "PAYLOAD_TOO_LARGE"
+    | "REQUEST_ABORTED"
+    | "REQUEST_TIMEOUT"
+    | "VALIDATION_ERROR"
+    | "VECTOR_DIMENSION_MISMATCH";
+
+export type JsonErrorResponse = {
+    status: "error";
+    error: string;
+    code: JsonErrorCode;
+    message: string;
+    resolution: string;
+    request_id: string;
+};
+
+type JsonErrorInput = {
+    code?: JsonErrorCode;
+    error: unknown;
+    message?: string;
+    requestId?: string;
+    resolution?: string;
+    statusCode: number;
+};
+
+function stringifyError(error: unknown): string {
+    if (typeof error === "string") {
+        return error;
+    }
+    if (error instanceof Error) {
+        return error.message;
+    }
+    if (error && typeof error === "object") {
+        if (
+            ("fieldErrors" in error || "formErrors" in error) &&
+            Object.keys(error).length <= 2
+        ) {
+            return "validation failed";
+        }
+        try {
+            return JSON.stringify(error);
+        } catch {
+            return "unserializable error";
+        }
+    }
+    return String(error);
+}
+
+function inferErrorCode(args: {
+    error: unknown;
+    message: string;
+    statusCode: number;
+}): JsonErrorCode {
+    const message = args.message.toLowerCase();
+
+    if (message.includes("collection not found")) {
+        return "COLLECTION_NOT_FOUND";
+    }
+    if (message.startsWith("vector dimension mismatch")) {
+        return "VECTOR_DIMENSION_MISMATCH";
+    }
+    if (message.includes("upsert request timed out")) {
+        return "REQUEST_TIMEOUT";
+    }
+    if (message.includes("request aborted")) {
+        return "REQUEST_ABORTED";
+    }
+    if (message.includes("ydb unavailable") || message.includes("health probe")) {
+        return "HEALTH_CHECK_FAILED";
+    }
+    if (
+        message.includes("unauthorized") ||
+        message.includes("anonymous requests require")
+    ) {
+        return "AUTHENTICATION_REQUIRED";
+    }
+    if (args.statusCode === 404) {
+        return "NOT_FOUND";
+    }
+    if (args.statusCode === 413) {
+        return "PAYLOAD_TOO_LARGE";
+    }
+    if (
+        args.statusCode === 422 ||
+        (args.statusCode === 400 && typeof args.error !== "string")
+    ) {
+        return "VALIDATION_ERROR";
+    }
+    if (args.statusCode === 400) {
+        return "BAD_REQUEST";
+    }
+    return "INTERNAL_ERROR";
+}
+
+function defaultResolution(code: JsonErrorCode): string {
+    switch (code) {
+        case "AUTHENTICATION_REQUIRED":
+            return "Send an api-key header, or provide identifiable client metadata for anonymous demo flows.";
+        case "BAD_REQUEST":
+            return "Check the request parameters and body, then retry with valid values.";
+        case "COLLECTION_NOT_FOUND":
+            return "Create the collection first, or check the collection name, api-key, and X-Tenant-Id namespace.";
+        case "HEALTH_CHECK_FAILED":
+            return "Retry after the service restarts, or verify YDB connectivity for the deployment.";
+        case "NOT_FOUND":
+            return "Check the URL path and HTTP method against the OpenAPI specification.";
+        case "PAYLOAD_TOO_LARGE":
+            return "Reduce the request body size or split the payload into smaller batches.";
+        case "REQUEST_ABORTED":
+            return "Retry the request with a complete body and keep the connection open until the response arrives.";
+        case "REQUEST_TIMEOUT":
+            return "Retry with a smaller batch, increase the client timeout, or split the upsert request.";
+        case "VALIDATION_ERROR":
+            return "Check the request JSON against the OpenAPI schema and required fields.";
+        case "VECTOR_DIMENSION_MISMATCH":
+            return "Use vectors with the same dimension as the collection vectors.size.";
+        case "INTERNAL_ERROR":
+            return "Retry later; if the error repeats, report the request_id to support.";
+    }
+}
+
+function getRequestId(res?: Response): string {
+    const contextRequestId = getRequestContext()?.requestId;
+    if (contextRequestId) {
+        return contextRequestId;
+    }
+
+    const headerValue = res?.getHeader?.("X-Request-Id");
+    if (typeof headerValue === "string" && headerValue.length > 0) {
+        return headerValue;
+    }
+    if (Array.isArray(headerValue) && typeof headerValue[0] === "string") {
+        return headerValue[0];
+    }
+    return "unknown";
+}
+
+export function createJsonErrorResponse(
+    args: JsonErrorInput,
+    res?: Response
+): JsonErrorResponse {
+    const message = args.message ?? stringifyError(args.error);
+    const code =
+        args.code ??
+        inferErrorCode({
+            error: args.error,
+            message,
+            statusCode: args.statusCode,
+        });
+
+    return {
+        status: "error",
+        error: message,
+        code,
+        message,
+        resolution: args.resolution ?? defaultResolution(code),
+        request_id: args.requestId ?? getRequestId(res),
+    };
+}
+
+export function sendJsonError(res: Response, args: JsonErrorInput): void {
+    res.status(args.statusCode).json(createJsonErrorResponse(args, res));
+}

--- a/test/Server.errorHandler.test.ts
+++ b/test/Server.errorHandler.test.ts
@@ -76,7 +76,7 @@ async function startServer(): Promise<{
 
 async function httpRequest(params: {
     baseUrl: string;
-    method: "POST";
+    method: "GET" | "POST";
     path: string;
     headers?: Record<string, string>;
     body?: string;
@@ -120,6 +120,7 @@ describe("buildServer() error handling", () => {
     it(
         "returns JSON error response for invalid JSON bodies (and preserves 400)",
         async () => {
+            vi.doUnmock("../src/middleware/requestLogger.js");
             const { server, baseUrl } = await startServer();
             try {
                 const res = await httpRequest({
@@ -128,6 +129,7 @@ describe("buildServer() error handling", () => {
                     path: "/collections/col/points/search",
                     headers: {
                         "content-type": "application/json",
+                        "x-request-id": "parse-error-test",
                     },
                     body: "{",
                 });
@@ -139,10 +141,18 @@ describe("buildServer() error handling", () => {
 
                 const parsed = JSON.parse(res.body) as {
                     status?: unknown;
+                    code?: unknown;
                     error?: unknown;
+                    message?: unknown;
+                    resolution?: unknown;
+                    request_id?: unknown;
                 };
                 expect(parsed.status).toBe("error");
                 expect(typeof parsed.error).toBe("string");
+                expect(parsed.code).toBe("VALIDATION_ERROR");
+                expect(parsed.message).toBe(parsed.error);
+                expect(typeof parsed.resolution).toBe("string");
+                expect(parsed.request_id).toBe("parse-error-test");
 
                 expect(loggerErrorMock).toHaveBeenCalled();
             } finally {
@@ -153,6 +163,37 @@ describe("buildServer() error handling", () => {
         },
         15_000
     );
+
+    it("returns structured JSON for unmatched API routes", async () => {
+        vi.doUnmock("../src/middleware/requestLogger.js");
+        const { server, baseUrl } = await startServer();
+        try {
+            const res = await httpRequest({
+                baseUrl,
+                method: "GET",
+                path: "/not-an-api-route",
+                headers: {
+                    "x-request-id": "missing-route-test",
+                },
+            });
+
+            expect(res.statusCode).toBe(404);
+            expect(String(res.headers["content-type"])).toContain(
+                "application/json"
+            );
+            expect(JSON.parse(res.body)).toMatchObject({
+                status: "error",
+                error: "route not found",
+                code: "NOT_FOUND",
+                message: "route not found",
+                request_id: "missing-route-test",
+            });
+        } finally {
+            await new Promise<void>((resolve, reject) => {
+                server.close((err) => (err ? reject(err) : resolve()));
+            });
+        }
+    });
 
     it(
         "logs upsert body-phase failure for malformed JSON without changing the 400 response",

--- a/test/helpers/routeTestHelpers.ts
+++ b/test/helpers/routeTestHelpers.ts
@@ -29,9 +29,12 @@ export function findHandler(
 
 export type MockBody = {
     status: string;
+    code?: string;
     result?: unknown;
     error?: unknown;
     message?: string;
+    resolution?: string;
+    request_id?: string;
     time?: number;
     usage?: unknown;
 };

--- a/test/helpers/routeTestHelpers.ts
+++ b/test/helpers/routeTestHelpers.ts
@@ -30,6 +30,7 @@ export function findHandler(
 export type MockBody = {
     status: string;
     code?: string;
+    details?: unknown;
     result?: unknown;
     error?: unknown;
     message?: string;

--- a/test/middleware/upsertRequestTimeout.test.ts
+++ b/test/middleware/upsertRequestTimeout.test.ts
@@ -118,4 +118,35 @@ describe("upsertRequestTimeout", () => {
 
         expect(next).not.toHaveBeenCalled();
     });
+
+    it("returns structured JSON when an upsert request times out", async () => {
+        const { respondUpsertRequestTimedOut } = await import(
+            "../../src/middleware/upsertRequestTimeout.js"
+        );
+        const req = createUpsertRequest();
+        const res = createResponse();
+
+        const didRespond = respondUpsertRequestTimedOut({
+            req,
+            res,
+            timeoutMs: 1000,
+            timeoutPhase: "processing",
+        });
+
+        expect(didRespond).toBe(true);
+        expect(
+            (res as unknown as { status: ReturnType<typeof vi.fn> }).status
+        ).toHaveBeenCalledWith(503);
+        expect(
+            (res as unknown as { json: ReturnType<typeof vi.fn> }).json
+        ).toHaveBeenCalledWith(
+            expect.objectContaining({
+                status: "error",
+                error: "upsert request timed out",
+                code: "REQUEST_TIMEOUT",
+                message: "upsert request timed out",
+                request_id: "unknown",
+            })
+        );
+    });
 });

--- a/test/routes/collections.test.ts
+++ b/test/routes/collections.test.ts
@@ -159,6 +159,42 @@ describe("collectionsRouter (HTTP, mocked service)", () => {
         expect(typeof res.body?.resolution).toBe("string");
     });
 
+    it("preserves flattened validation details on collection errors", async () => {
+        const handler = findHandler(collectionsRouter, "put", "/:collection");
+        const req = createRequest({
+            method: "PUT",
+            collection: "col",
+            body: {},
+        });
+        const res = createMockRes({ authUserUid: "1120000000101690" });
+        const details = {
+            fieldErrors: {
+                vectors: ["Required"],
+            },
+            formErrors: [],
+        };
+
+        const error = new QdrantServiceError(400, {
+            status: "error",
+            error: details,
+        });
+
+        vi.mocked(collectionService.createCollection).mockRejectedValueOnce(
+            error
+        );
+
+        await handler(req, res);
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body).toMatchObject({
+            status: "error",
+            error: "validation failed",
+            code: "VALIDATION_ERROR",
+            message: "validation failed",
+            details,
+        });
+    });
+
     it("handles get and delete collection through service", async () => {
         const getHandler = findHandler(
             collectionsRouter,

--- a/test/routes/collections.test.ts
+++ b/test/routes/collections.test.ts
@@ -149,7 +149,14 @@ describe("collectionsRouter (HTTP, mocked service)", () => {
 
         await handler(req, res);
         expect(res.statusCode).toBe(422);
-        expect(res.body).toMatchObject({ status: "error", error: "invalid" });
+        expect(res.body).toMatchObject({
+            status: "error",
+            error: "invalid",
+            code: "VALIDATION_ERROR",
+            message: "invalid",
+            request_id: "unknown",
+        });
+        expect(typeof res.body?.resolution).toBe("string");
     });
 
     it("handles get and delete collection through service", async () => {
@@ -295,9 +302,14 @@ describe("collectionsRouter (HTTP, mocked service)", () => {
 
         expect(collectionService.getCollection).not.toHaveBeenCalled();
         expect(res.statusCode).toBe(400);
-        expect(res.body).toEqual({
+        expect(res.body).toMatchObject({
             status: "error",
             error: "Anonymous requests require api-key or identifiable client metadata.",
+            code: "AUTHENTICATION_REQUIRED",
+            message:
+                "Anonymous requests require api-key or identifiable client metadata.",
+            request_id: "unknown",
         });
+        expect(typeof res.body?.resolution).toBe("string");
     });
 });

--- a/test/routes/points.test.ts
+++ b/test/routes/points.test.ts
@@ -411,7 +411,14 @@ describe("pointsRouter (HTTP, mocked service)", () => {
         await searchHandler(req, res);
 
         expect(res.statusCode).toBe(400);
-        expect(res.body).toEqual({ status: "error", error: "bad search" });
+        expect(res.body).toMatchObject({
+            status: "error",
+            error: "bad search",
+            code: "BAD_REQUEST",
+            message: "bad search",
+            request_id: "unknown",
+        });
+        expect(typeof res.body?.resolution).toBe("string");
     });
 
     it("returns 400 and payload for vector dimension mismatch on upsert", async () => {
@@ -443,10 +450,14 @@ describe("pointsRouter (HTTP, mocked service)", () => {
         await putHandler(req, res);
 
         expect(res.statusCode).toBe(400);
-        expect(res.body).toEqual({
+        expect(res.body).toMatchObject({
             status: "error",
             error: "Vector dimension mismatch for id=p1: got 4096, expected 3072",
+            code: "VECTOR_DIMENSION_MISMATCH",
+            message: "Vector dimension mismatch for id=p1: got 4096, expected 3072",
+            request_id: "unknown",
         });
+        expect(typeof res.body?.resolution).toBe("string");
     });
 
     it("logs unexpected errors and returns 500 for delete points", async () => {
@@ -470,10 +481,14 @@ describe("pointsRouter (HTTP, mocked service)", () => {
 
         expect(loggerErrorMock).toHaveBeenCalled();
         expect(res.statusCode).toBe(500);
-        expect(res.body).toEqual({
+        expect(res.body).toMatchObject({
             status: "error",
             error: "boom",
+            code: "INTERNAL_ERROR",
+            message: "boom",
+            request_id: "unknown",
         });
+        expect(typeof res.body?.resolution).toBe("string");
     });
 
     it("returns 500 and schedules exit on compilation timeout during upsert (PUT)", async () => {
@@ -499,10 +514,14 @@ describe("pointsRouter (HTTP, mocked service)", () => {
         await putHandler(req, res);
 
         expect(res.statusCode).toBe(500);
-        expect(res.body).toEqual({
+        expect(res.body).toMatchObject({
             status: "error",
             error: "compilation timeout",
+            code: "INTERNAL_ERROR",
+            message: "compilation timeout",
+            request_id: "unknown",
         });
+        expect(typeof res.body?.resolution).toBe("string");
         expect(scheduleExitMock).toHaveBeenCalledWith(1);
     });
 
@@ -558,10 +577,14 @@ describe("pointsRouter (HTTP, mocked service)", () => {
         await postUpsertHandler(req, res);
 
         expect(res.statusCode).toBe(500);
-        expect(res.body).toEqual({
+        expect(res.body).toMatchObject({
             status: "error",
             error: "compilation timeout",
+            code: "INTERNAL_ERROR",
+            message: "compilation timeout",
+            request_id: "unknown",
         });
+        expect(typeof res.body?.resolution).toBe("string");
         expect(loggerErrorMock).toHaveBeenCalled();
         expect(scheduleExitMock).toHaveBeenCalledWith(1);
     });
@@ -619,10 +642,14 @@ describe("pointsRouter (HTTP, mocked service)", () => {
         await searchHandler(req, res);
 
         expect(res.statusCode).toBe(500);
-        expect(res.body).toEqual({
+        expect(res.body).toMatchObject({
             status: "error",
             error: "compilation timeout",
+            code: "INTERNAL_ERROR",
+            message: "compilation timeout",
+            request_id: "unknown",
         });
+        expect(typeof res.body?.resolution).toBe("string");
         expect(scheduleExitMock).toHaveBeenCalledWith(1);
     });
 
@@ -650,10 +677,14 @@ describe("pointsRouter (HTTP, mocked service)", () => {
         await queryHandler(req, res);
 
         expect(res.statusCode).toBe(500);
-        expect(res.body).toEqual({
+        expect(res.body).toMatchObject({
             status: "error",
             error: "compilation timeout",
+            code: "INTERNAL_ERROR",
+            message: "compilation timeout",
+            request_id: "unknown",
         });
+        expect(typeof res.body?.resolution).toBe("string");
         expect(loggerErrorMock).toHaveBeenCalled();
         expect(scheduleExitMock).toHaveBeenCalledWith(1);
     });
@@ -729,10 +760,14 @@ describe("pointsRouter (HTTP, mocked service)", () => {
         await retrieveHandler(req, res);
 
         expect(res.statusCode).toBe(404);
-        expect(res.body).toEqual({
+        expect(res.body).toMatchObject({
             status: "error",
             error: "collection not found",
+            code: "COLLECTION_NOT_FOUND",
+            message: "collection not found",
+            request_id: "unknown",
         });
+        expect(typeof res.body?.resolution).toBe("string");
     });
 
     it("returns validation error when anonymous identity cannot be resolved", async () => {
@@ -762,9 +797,14 @@ describe("pointsRouter (HTTP, mocked service)", () => {
 
         expect(pointsService.retrievePoints).not.toHaveBeenCalled();
         expect(res.statusCode).toBe(400);
-        expect(res.body).toEqual({
+        expect(res.body).toMatchObject({
             status: "error",
             error: "Anonymous requests require api-key or identifiable client metadata.",
+            code: "AUTHENTICATION_REQUIRED",
+            message:
+                "Anonymous requests require api-key or identifiable client metadata.",
+            request_id: "unknown",
         });
+        expect(typeof res.body?.resolution).toBe("string");
     });
 });


### PR DESCRIPTION
### Load test (soak, one_table_exact)

| Metric | Value |
|--------|-------|
| Operations/sec | 67.39 |
| Search p95 | 67.19999999999982 ms |
| Search p99 | 0 ms |
| Error rate | 0.0183 % |
### Load test (stress, one_table_exact)

| Metric | Value |
|--------|-------|
| Max VUs reached | 600 |
| Average RPS | 166.96 |
| Search p95 | 4856 ms |
| Search p99 | 0 ms |
| Error rate | 0.0147 % |

#### Breaking point

Breaking point detected at **600 VUs** (~166.96 RPS).